### PR TITLE
Verify hospital self-install contract

### DIFF
--- a/.github/workflows/hospital-self-install.yml
+++ b/.github/workflows/hospital-self-install.yml
@@ -85,4 +85,4 @@ jobs:
       - name: Verify container stays non-root
         run: test "$(docker run --rm --entrypoint sh careos:hospital-ci -c 'id -u')" != "0"
 
-# PR verification marker: exercises the complete hospital self-install contract.
+# PR verification marker: rerun after direct-entrypoint import-path fix.

--- a/.github/workflows/hospital-self-install.yml
+++ b/.github/workflows/hospital-self-install.yml
@@ -84,3 +84,5 @@ jobs:
         run: docker build --tag careos:hospital-ci .
       - name: Verify container stays non-root
         run: test "$(docker run --rm --entrypoint sh careos:hospital-ci -c 'id -u')" != "0"
+
+# PR verification marker: exercises the complete hospital self-install contract.


### PR DESCRIPTION
CI-only verification PR. The branch differs from `main` only by a workflow comment so the pull-request path filter runs the complete hospital self-install suite against the current repository state. If green, this can be closed/merged without product impact.