### PR TITLE
Verify future healthcare foundation contracts

### DIFF
--- a/.github/workflows/future-healthcare-foundation.yml
+++ b/.github/workflows/future-healthcare-foundation.yml
@@ -47,3 +47,5 @@ jobs:
           tests/test_offline_policy.py
           tests/test_time_returned_to_care.py
           tests/test_clinical_context_graph.py
+
+# PR verification marker: exercise future-healthcare foundation contracts.


### PR DESCRIPTION
CI-only verification PR. The branch differs from `main` only by a workflow comment so the pull-request filter runs the focused future-healthcare foundation suite against the current repository state: degraded/offline safety, safety-gated Time Returned to Care, and clinical graph provenance/patient-scope invariants.