### PR TITLE
Verify hospital-scale foundation contracts

### DIFF
--- a/.github/workflows/hospital-self-install.yml
+++ b/.github/workflows/hospital-self-install.yml
@@ -113,3 +113,5 @@ jobs:
         run: docker build --tag careos:hospital-ci .
       - name: Verify container stays non-root
         run: test "$(docker run --rm --entrypoint sh careos:hospital-ci -c 'id -u')" != "0"
+
+# Verification marker: MPI + review pack + rollout + compatibility + HL7 connector.


### PR DESCRIPTION
CI-only verification PR. It correctly exposed a trusted-MPI test-fixture mismatch (`trusted_mpi_resolver_available` was not declared). The fixture and CLI boundary were fixed on `main`; superseded by #49.