### PR TITLE
Create CareOS real-world proof sprint 1

### DIFF
--- a/proof/CLINICIAN_STUDY_PREREG.md
+++ b/proof/CLINICIAN_STUDY_PREREG.md
@@ -1,0 +1,110 @@
+# Clinician Study Preregistration — Sprint 1
+
+Freeze this document before participant `P001` begins. Changes after first participant must be appended under **Protocol deviations**; do not silently edit the original hypothesis.
+
+## Study type
+
+Internal product/usability evaluation using **synthetic cases only**. It is not clinical validation and does not authorize live patient-data research. If the intent changes to publish generalisable research or use real patient/workflow data, obtain the institutionally appropriate ethics/privacy/governance review first.
+
+## Primary question
+
+For physician morning review + documentation preparation, does CareOS reduce task time/friction while preserving correctness, pending-work detection and source verification?
+
+## Participants
+
+Target: 5–10 clinicians for the first workflow family, with mixed experience levels where feasible.
+
+Use pseudonymous participant IDs only. Do not export participant names, patient data or free-text from real cases.
+
+## Design
+
+Paired, counterbalanced, matched synthetic cases:
+
+- odd participant IDs: baseline A -> CareOS B;
+- even participant IDs: CareOS A -> baseline B.
+
+A valid pair must use different matched variants and order positions 1 and 2.
+
+## Primary outcomes
+
+Per observation:
+
+- elapsed task seconds;
+- correct task completion;
+- missed pending items;
+- wrong answers;
+- unsupported claims;
+- source opens / verification behavior;
+- corrections;
+- context switches / searches / copy-paste;
+- cognitive effort 1–5;
+- explicit safety stops.
+
+## Safety gate
+
+Any of the following blocks a positive claim for the affected pair/set:
+
+- wrong patient;
+- increased missed pending work;
+- unsupported consequential claim;
+- stale/preliminary information treated as current/final;
+- draft mistaken for clinical recommendation;
+- material verification collapse.
+
+Speed never overrides this gate.
+
+## Directional success threshold
+
+Do not publish/highlight a directional result for this workflow until:
+
+- >= 5 complete safe pairs;
+- both order directions represented;
+- every pair uses distinct matched variants;
+- zero safety-stop events in the highlighted set;
+- no increase in correction burden that negates the time result;
+- individual-pair distribution shown alongside median/aggregate.
+
+Product targets such as >=90% task success, lower median time, median cognitive effort <=2/5 and >=80% willingness-to-reuse are **targets to test**, not prior results.
+
+## Baseline integrity
+
+The baseline condition must be credible enough to represent the current task. If participants say it is unrealistically difficult/easy, record this as a protocol limitation rather than interpreting the CareOS delta as real-world time savings.
+
+## Session script
+
+1. Explain synthetic-only nature in <=20 seconds.
+2. Do not teach navigation beyond what a first-time user would reasonably receive.
+3. Start timing when the task is visible.
+4. Observe; do not rescue unless the participant is blocked beyond useful observation.
+5. Record interventions as protocol events.
+6. End timing at the predefined task completion point.
+7. Ask only the five debrief questions in `CLINICIAN_TEST.md`.
+
+## Analysis
+
+Use the existing aggregator. Report:
+
+- each pair;
+- median and range;
+- safety/correctness outcomes;
+- source-check behavior;
+- cognitive effort;
+- participant friction themes;
+- protocol deviations.
+
+Do not convert a tiny synthetic usability sample into a clinical-effectiveness claim.
+
+## Stop / redesign criteria
+
+Pause the current workflow hypothesis if:
+
+- any repeatable safety misunderstanding appears;
+- clinicians cannot identify pending/uncertain state;
+- source verification meaningfully drops;
+- the baseline comparison is invalid;
+- users repeatedly say the task does not reflect real work;
+- time savings depend on skipping necessary verification.
+
+## Protocol deviations
+
+None at preregistration.

--- a/proof/EVIDENCE_LEDGER.yaml
+++ b/proof/EVIDENCE_LEDGER.yaml
@@ -1,0 +1,113 @@
+version: 1
+updated: 2026-08-24
+rules:
+  - every external session or review changes at least one claim state or adds a limitation
+  - negative evidence is retained
+  - synthetic evidence cannot upgrade a claim to real-world proven
+  - submitted evidence is not verified evidence
+  - external reviewer feedback is critique unless the reviewer has explicit institutional authority
+
+claims:
+  - id: C1-workflow-useful
+    claim: physician morning review is a valuable first CareOS workflow
+    current_state: research_hypothesis
+    owner: product
+    verifier: external_clinicians
+    next_evidence:
+      - five_or_more_safe_counterbalanced_clinician_pairs
+      - qualitative_observation_of_realistic_task_fit
+    falsifiers:
+      - workflow_does_not_match_real_work
+      - careos_duplicates_existing_fast_path
+      - verification_burden_erases_benefit
+    evidence: []
+
+  - id: C2-time-returned
+    claim: CareOS can reduce time/friction without reducing safety or verification
+    current_state: external_evidence_required
+    owner: study_facilitator
+    verifier: study_protocol_and_external_clinicians
+    next_evidence:
+      - paired_observations
+      - safety_gate_pass
+      - source_verification_behavior
+    falsifiers:
+      - no_time_improvement
+      - more_errors
+      - more_missed_pending_items
+      - verification_collapse
+    evidence: []
+
+  - id: C3-clinical-truth-useful
+    claim: source-linked clinical truth layer is useful enough for production-oriented workflow study
+    current_state: blocked
+    owner: clinical_truth_engineering
+    verifier: benchmark_plus_clinician_behavior
+    known_evidence:
+      - frozen_500_case_holdout_recall_26_32_percent
+      - review_case_burden_100_percent
+    next_evidence:
+      - fresh_development_corpus_improvement_without_holdout_tuning
+      - clinician_behavior_on_changed_pending_conflicting_cases
+    falsifiers:
+      - poor_recall_persists
+      - review_burden_remains_unusable
+    evidence: []
+
+  - id: C4-hospital-discovery
+    claim: a non-secret hospital capability manifest can capture enough reality to drive review and integration planning
+    current_state: research_hypothesis
+    owner: integration
+    verifier: hospital_it_dpo_ciso
+    next_evidence:
+      - one_real_hospital_manifest
+      - reviewer_corrections
+      - unknowns_and_custom_work_logged
+    falsifiers:
+      - critical_information_cannot_be_represented
+      - discovery_requires_mostly_bespoke_unstructured_work
+    evidence: []
+
+  - id: C5-fhir-isik-real
+    claim: CareOS read-only FHIR/ISiK assumptions survive a real approved sandbox
+    current_state: external_evidence_required
+    owner: integration
+    verifier: hospital_or_vendor_sandbox
+    next_evidence:
+      - named_vendor_and_version
+      - capability_statement
+      - auth_and_patient_context_behavior
+      - measured_partial_read_latency_and_profile_gaps
+    falsifiers:
+      - incompatible_profiles_or_auth
+      - patient_context_cannot_be_resolved_safely
+      - partial_reads_create_unsafe_state
+    evidence: []
+
+  - id: C6-review-pack-useful
+    claim: generated CareOS review artifacts help DPO CISO and hospital IT review the system
+    current_state: tested_synthetically
+    owner: platform
+    verifier: external_reviewers
+    next_evidence:
+      - three_independent_reviewer_perspectives
+      - missing_questions_and_corrections_logged
+    falsifiers:
+      - reviewers_need_material_information_not_representable
+      - package_hides_critical_risk_or_data_flow
+    evidence: []
+
+  - id: C7-shadow-ready
+    claim: CareOS is ready to request a governed read-only shadow evaluation
+    current_state: blocked
+    owner: pilot_sponsor
+    verifier: institution
+    prerequisites:
+      - C1-workflow-useful supported
+      - C2-time-returned directional_support_or_clear_non_time_value
+      - C4-hospital-discovery supported
+      - C5-fhir-isik-real supported_or_approved_equivalent_source_path
+      - C6-review-pack-useful supported
+      - intended_use_and_clinical_safety_review
+      - privacy_security_and_operational_approval
+    evidence: []

--- a/proof/EXTERNAL_PROOF_TARGETS.md
+++ b/proof/EXTERNAL_PROOF_TARGETS.md
@@ -1,0 +1,103 @@
+# External Proof Targets — ordered by evidence value
+
+This is a target map, not evidence that any organisation has agreed to participate.
+
+## 1. Real clinicians — synthetic paired sessions
+
+**Ask:** 20–30 minutes, no patient data, complete the same bounded workflow baseline vs CareOS.
+
+**Evidence produced:**
+- observed task time;
+- correctness/pending detection;
+- verification behavior;
+- friction/cognitive effort;
+- workflow realism;
+- falsifiable UX/safety findings.
+
+**Why first:** can start without hospital system access and directly tests the highest-value user claim.
+
+## 2. Charité CEED — clinical usability / proof-of-concept critique
+
+Public service description: https://ceed.charite.de/
+
+CEED publicly describes usability/UX testing, proof-of-concept studies, regulatory support and access to clinical expertise.
+
+**Ask:** critique the CareOS first workflow and advise on the smallest realistic usability/PoC path.
+
+**Evidence sought:**
+- professional clinical usability assessment;
+- human-factors gaps;
+- realistic next study design;
+- regulatory/clinical-practice constraints.
+
+## 3. Charité Institute of Medical Informatics / EVIDOC — implementation-science critique
+
+Public project: https://medinfo.charite.de/en/research/ag_clinical_implementation_science_in_digital_health_cidh/evidoc/
+
+EVIDOC studies how AI-supported documentation can be integrated effectively and sustainably into clinical routine, including workflow effects and implementation conditions.
+
+**Ask:** challenge the Time Returned to Care protocol and implementation assumptions; identify what would count as meaningful evidence.
+
+**Evidence sought:**
+- study-design critique;
+- workflow/implementation factors missing from CareOS;
+- external falsification of time-savings assumptions;
+- advice on what can/cannot generalise from synthetic paired sessions.
+
+## 4. Production hospital-platform company / integration team
+
+Example target already mapped in this repository: Recare / equivalent hospital integration platform.
+
+**Ask:** 45-minute architecture teardown, not a sales demo.
+
+Questions:
+- Which CareOS integration assumptions are naive?
+- What is configuration vs custom engineering in real hospitals?
+- Which lifecycle/provenance patterns matter in production?
+- Where would CareOS duplicate mature infrastructure?
+- What would a credible sandbox trace look like?
+
+**Evidence produced:**
+- architecture corrections;
+- overlap removed;
+- real integration bottlenecks;
+- candidate vendor/environment for compatibility proof.
+
+## 5. First hospital IT + DPO/CISO discovery workshop
+
+**Ask:** complete a non-secret capability manifest. No patient data, credentials or system access required.
+
+**Evidence produced:**
+- named system/vendor/version map where allowed;
+- real interface availability;
+- identity/context path;
+- actual review/approval graph;
+- sandbox/deidentified options;
+- blockers and owners.
+
+## 6. Vendor / approved sandbox
+
+**Ask:** read-only/deidentified interoperability exercise against a named vendor/version.
+
+**Evidence produced:**
+- capability statement;
+- auth behavior;
+- FHIR/ISiK/profile gaps;
+- patient-context behavior;
+- partial read / corrected-result behavior;
+- measured engineering hours to first useful workflow.
+
+## Advancement order
+
+Do not wait for all channels sequentially. Run independent tracks in parallel where safe:
+
+```text
+clinician sessions ---------┐
+CEED / usability -----------┤
+implementation critique ----┤
+production architecture ----┼--> corrected pilot package
+hospital discovery ---------┤
+                            └--> approved sandbox --> shadow request
+```
+
+The next stage is earned by evidence, not calendar time.

--- a/proof/HOSPITAL_DISCOVERY_WORKSHOP.md
+++ b/proof/HOSPITAL_DISCOVERY_WORKSHOP.md
@@ -1,0 +1,127 @@
+# Hospital Discovery Workshop — 60 minutes, no PHI
+
+Purpose: create the **first real hospital capability manifest** and expose wrong assumptions before asking for system access.
+
+This is not an approval meeting and not a product demo. Do not request patient data, credentials or secrets.
+
+## Minimum participants
+
+- clinical workflow owner / clinician;
+- hospital IT / integration owner;
+- privacy or data-protection representative;
+- security/CISO representative where feasible;
+- optional procurement/operations owner.
+
+## Output
+
+By the end, we should have a non-secret draft containing:
+
+- actual workflow boundary and owner;
+- named systems and vendor/product/version where known;
+- source types used in the workflow;
+- interface types actually available (FHIR/ISiK, HL7 v2, documents, vendor API, other);
+- identity/patient-context mechanism;
+- read/write boundary;
+- network/auth ownership;
+- environments that may be available (test/sandbox/deidentified/shadow);
+- data-protection/security reviewers and required review artifacts;
+- operational owner, stop/rollback expectations;
+- unknowns, contradictions and bespoke work.
+
+## Agenda
+
+### 0–10 min — real workflow archaeology
+
+Ask the clinician to narrate one recent normal case without patient-identifying details:
+
+1. What starts the task?
+2. Which systems/screens/documents are opened?
+3. Where do changed/pending results appear?
+4. Where does the clinician manually reconcile information?
+5. Which step causes calls/messages/searching/copy-paste?
+6. What mistake or missed pending item would be dangerous?
+7. What is the real end state of the task?
+
+Do not show CareOS until this baseline is understood.
+
+### 10–25 min — system map
+
+For every source:
+
+| Question | Capture |
+|---|---|
+| System | product/vendor/name |
+| Version | exact if known |
+| Owner | team/role |
+| Data used | categories, no PHI examples |
+| Interface | FHIR/ISiK/HL7v2/API/document/other |
+| Patient context | how identity/encounter is selected |
+| Lifecycle | preliminary/final/corrected/cancelled available? |
+| Availability | normal outages/partial-read behavior |
+| Test path | sandbox/deidentified/test environment? |
+
+### 25–35 min — CareOS boundary
+
+Show only the narrow target:
+
+- read-only source-linked context;
+- no autonomous diagnosis/treatment;
+- no hidden write-back;
+- pending/unavailable preserved;
+- human remains authority;
+- synthetic/deidentified first.
+
+Ask: **Which assumption is wrong in your hospital?**
+
+### 35–50 min — review path
+
+Map actual required reviewers and what each needs:
+
+- Clinical / patient safety
+- Datenschutz / DPO
+- Security / CISO
+- IT integration
+- Betriebsrat / workforce where applicable
+- Procurement / Legal
+- Operations / support
+- Regulatory/quality where applicable
+
+For each:
+
+`owner -> question -> evidence needed -> who can verify -> prerequisite -> can run in parallel?`
+
+### 50–60 min — smallest next proof
+
+Choose exactly one:
+
+1. synthetic clinician sessions only;
+2. real non-secret capability manifest;
+3. approved vendor/test sandbox;
+4. deidentified interface sample;
+5. governed shadow evaluation preparation.
+
+Do not jump to live identifiable data because the demo is compelling.
+
+## Red flags to record, not solve away
+
+- no reliable patient-context mechanism;
+- vendor interface differs from documentation;
+- corrected/preliminary lifecycle not available;
+- read-only access still exposes excessive data;
+- no test environment;
+- unclear system owner;
+- review path depends on undocumented personal knowledge;
+- procurement/licensing forbids intended use;
+- workflow benefit disappears after necessary verification;
+- critical integration requires write authority.
+
+## Definition of done
+
+The workshop is complete when:
+
+- at least one current workflow is mapped end-to-end;
+- system/vendor/version unknowns are explicit;
+- no secrets/PHI were captured;
+- every blocker has an owner or is explicitly owner-unknown;
+- the next smallest safe evidence step is chosen;
+- `proof/EVIDENCE_LEDGER.yaml` is updated with supported/falsified/blocked/unknown findings.

--- a/proof/INDEPENDENT_REVIEW_PACKET.md
+++ b/proof/INDEPENDENT_REVIEW_PACKET.md
@@ -1,0 +1,117 @@
+# CareOS Independent Review Packet
+
+Purpose: invite experts to **find reasons CareOS should not advance yet**.
+
+Reviewer feedback is evidence of critique, not institutional approval unless the reviewer explicitly has that authority.
+
+## Send reviewers only what they need
+
+Start with:
+
+1. `README.md` — 5-minute orientation;
+2. `docs/CURRENT_STATUS_AND_GAPS.md` — current truth boundary;
+3. `docs/CLAIM_EVIDENCE_MATRIX.md` — falsifiable claims;
+4. generated hospital review pack if reviewing a real non-secret manifest;
+5. one narrow workflow demo / synthetic study.
+
+Do not overwhelm them with the whole repository.
+
+## Review A — clinician / clinical safety
+
+Ask:
+
+1. Is the intended first workflow clinically meaningful or artificial?
+2. Which information/state could CareOS present dangerously even if technically source-linked?
+3. Does `pending / unavailable / preliminary / corrected` match clinical mental models?
+4. What would make you stop a shadow evaluation immediately?
+5. Is our Definition of Done for the first workflow correct?
+6. Which error classes are missing?
+7. Where could source provenance create false reassurance rather than trust?
+8. What must be independently measured before any real workflow use?
+
+Output:
+
+- severity-ranked findings;
+- missing safety cases;
+- corrected workflow/DoD;
+- advance / redesign / stop recommendation for synthetic external study only.
+
+## Review B — privacy + security
+
+Ask:
+
+1. Is the proposed data scope actually minimal for the intended workflow?
+2. Which data-flow or processor/subprocessor fact is missing?
+3. Which identity/role/treatment-context assumption is unsafe?
+4. Could provenance/audit itself leak sensitive data?
+5. What evidence would you require before approving a sandbox or shadow evaluation?
+6. Which retention/deletion/backup path is underspecified?
+7. What attacker/failure mode is missing from the threat model?
+8. Is the read-only boundary technically enforceable rather than contractual only?
+
+Output:
+
+- required evidence list;
+- unacceptable assumptions;
+- minimum controls for next environment;
+- explicit non-approval statement unless reviewer is institutionally authorised.
+
+## Review C — hospital IT / integration
+
+Ask:
+
+1. Which source/interface assumptions are unrealistic?
+2. Can our capability manifest represent your actual environment without secrets?
+3. How is patient/encounter context really resolved?
+4. What does FHIR/ISiK expose versus what still comes through HL7v2/documents/vendor-specific paths?
+5. How are corrections/retries/outages represented in reality?
+6. What work is configuration versus custom engineering?
+7. What would be the smallest approved sandbox path?
+8. What would make deployment #2 easier than deployment #1 — or why would it not?
+
+Output:
+
+- corrected system map;
+- named vendor/version where allowed;
+- sandbox candidate;
+- bespoke-work estimate;
+- top 5 integration risks.
+
+## Review D — regulatory / quality
+
+Only after intended use and deployment context are fixed enough to review.
+
+Ask:
+
+1. Is the intended use stated narrowly enough to classify responsibly?
+2. Which claims create medical-device / AI / clinical-safety implications?
+3. What quality/risk/change-control evidence is missing?
+4. Which human factors/usability evidence is necessary?
+5. Which changes would require reassessment?
+6. What may CareOS safely claim today, and what wording should be prohibited?
+
+Do not ask the reviewer to “certify” the project informally.
+
+## Finding format
+
+Every finding should become a durable record:
+
+```yaml
+id: EXT-001
+review_type: clinical_safety
+severity: critical | high | medium | low | observation
+claim_affected: C1-workflow-useful
+finding: "..."
+evidence_seen:
+  - "..."
+recommended_action: "..."
+status: open | accepted | disputed | resolved
+owner: "role/team"
+verification_needed: "what proves resolution"
+```
+
+## Advancement rule
+
+A review is valuable when it changes something: a claim weakens/strengthens, a gate opens/closes, a test is added, or an assumption becomes explicitly unknown.
+
+A meeting that ends only with “looks interesting” is not evidence.

--- a/proof/README.md
+++ b/proof/README.md
@@ -1,0 +1,72 @@
+# CareOS Real-World Proof Sprint 1
+
+Status: **pre-hospital external-evidence campaign**. No identifiable patient data. No clinical-use claim.
+
+## Goal
+
+Move CareOS from a strong synthetic/runnable prototype to **independently inspectable real-world evidence**.
+
+We do not win by adding features. We win when a skeptical outsider can inspect an evidence trail and say exactly which claims survived reality, which failed, and why.
+
+## Proof ladder
+
+1. **Real clinicians on synthetic cases** — observed behavior, not opinions.
+2. **Independent clinical/safety/privacy/security critique** — named role, explicit findings, corrections.
+3. **Real hospital capability manifest** — systems/vendor versions/interfaces/identity/owners, no secrets or PHI.
+4. **Approved vendor/deidentified sandbox** — actual FHIR/ISiK/HL7 behavior and measured integration effort.
+5. **Governed shadow workflow** — CareOS runs without influencing care; compare against normal work.
+6. **Bounded read-only pilot** — only after institutional approvals and stop/rollback criteria.
+7. **Second site/vendor** — test whether knowledge is reusable rather than bespoke consulting.
+
+## Sprint-1 graduation
+
+Sprint 1 is complete only when all of these exist:
+
+- >= 5 complete safe paired clinician sessions for one workflow family;
+- observed baseline and CareOS timings, errors, source checks and effort;
+- zero hidden safety-stop events in any result presented as positive;
+- at least 3 independent reviewer perspectives (clinical/safety, privacy/security, hospital IT/integration);
+- one real non-secret hospital capability manifest completed with hospital staff;
+- every finding entered in `proof/EVIDENCE_LEDGER.yaml` as **supported / falsified / blocked / unknown**;
+- at least one assumption is corrected or falsified. If nothing changes, the test was probably too friendly.
+
+## First bounded workflow
+
+**Physician morning review + documentation preparation.**
+
+The question is not “Do you like CareOS?”
+
+> Can a clinician reconstruct changed/pending/critical context and prepare the bounded documentation task faster or with less friction **without more errors or verification collapse**?
+
+Use the existing `docs/TIME_RETURNED_TO_CARE_STUDY.md`, `CLINICIAN_TEST.md` and study runner. This directory adds the external-evidence discipline around them.
+
+## Evidence rules
+
+- Synthetic cases stay synthetic.
+- Participants receive pseudonymous codes; do not store names in exported study records.
+- “Uploaded” / “submitted” / “reviewed” are not automatically “verified”.
+- Negative results stay visible.
+- Unknown timing stays unknown.
+- Reviewer comments are evidence, not approvals.
+- A hospital manifest is not permission to access systems.
+- A sandbox result is not production compatibility.
+- A shadow result is not clinical validation.
+
+## OpenAction role
+
+Use OpenAction as the adoption/evidence coordination layer for the pilot:
+
+`claim -> required evidence -> owner -> verifier -> status -> next unlock`
+
+CareOS remains the clinical product and source-linked workflow layer. OpenAction tracks why the next real-world step is or is not justified.
+
+## Immediate sequence
+
+1. Run facilitator dry-run; delete dummy evidence afterwards.
+2. Recruit first 5–10 clinicians for synthetic paired sessions.
+3. Freeze the preregistration before participant #1.
+4. Run sessions and export machine-readable observations.
+5. Aggregate without hiding individual pairs.
+6. Conduct external reviewer workshop using `INDEPENDENT_REVIEW_PACKET.md`.
+7. Complete one hospital discovery workshop using `HOSPITAL_DISCOVERY_WORKSHOP.md`.
+8. Decide: **advance / redesign / stop**.

--- a/proof/SESSION_OBSERVER_TEMPLATE.md
+++ b/proof/SESSION_OBSERVER_TEMPLATE.md
@@ -1,0 +1,84 @@
+# External Session Observer Template
+
+Use one copy per synthetic participant/reviewer session. Keep personal identity outside the repository/export.
+
+## Session metadata
+
+- Participant code: `P___`
+- Role: physician / nursing / case-management / reviewer
+- Workflow family:
+- Date:
+- Facilitator code:
+- Condition order: baseline-first / CareOS-first
+- Case variants:
+- Any protocol deviation before start? yes/no
+
+## Before task
+
+- Participant confirms the task resembles real work: yes / partly / no
+- If partly/no, why (no patient-identifying detail):
+- Relevant current tools/systems mentioned (generic or approved names only):
+
+## Observation — baseline
+
+- elapsed seconds:
+- task success: yes/no
+- wrong answers:
+- missed pending items:
+- systems/screens opened:
+- searches:
+- context switches:
+- copy/paste:
+- clarification contacts:
+- source checks:
+- corrections:
+- cognitive effort 1–5:
+- safety stop? yes/no + code:
+- facilitator intervention? yes/no + why:
+
+## Observation — CareOS
+
+- elapsed seconds:
+- task success: yes/no
+- wrong answers:
+- missed pending items:
+- systems/screens opened:
+- searches:
+- context switches:
+- copy/paste:
+- clarification contacts:
+- source checks:
+- corrections:
+- accepted without source check:
+- cognitive effort 1–5:
+- safety stop? yes/no + code:
+- facilitator intervention? yes/no + why:
+
+## Five debrief answers
+
+1. What saved the most time?
+2. Where did you hesitate?
+3. What information is missing for trust?
+4. What would you remove?
+5. If we solve only one problem next, which one?
+
+## Observer interpretation
+
+Do not write “user liked it”. Record falsifiable findings.
+
+- Claim(s) supported:
+- Claim(s) weakened/falsified:
+- New unknown:
+- New regression test needed:
+- UX change needed:
+- Safety/control change needed:
+- Evidence ledger IDs to update:
+
+## Advancement decision for this session
+
+- [ ] supports continuing current hypothesis
+- [ ] requires redesign before next participant
+- [ ] triggers safety stop / pause
+- [ ] insufficient evidence / invalid session
+
+Reason:


### PR DESCRIPTION
## Goal
Move CareOS from synthetic/runnable proof toward external real-world evidence without touching identifiable patient data or weakening claim boundaries.

## Adds
- real-world proof ladder and graduation gates
- preregistered clinician paired-study protocol
- machine-readable claim/evidence ledger
- 60-minute hospital discovery workshop
- independent clinical/privacy/security/integration/regulatory review packet
- external session observer template

## Core rule
Every external session must support, falsify, block, or clarify a claim. `Looks interesting` is not evidence.

This PR does not claim clinical validation, production approval, or permission for live patient data.