### PR TITLE
Make CareOS README share-ready

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,36 +4,20 @@
 
 ### **Return time to care — without making clinical information less trustworthy.**
 
-A clinician-first **interoperability, context and assurance layer** that sits beside existing healthcare systems, composes source-linked clinical context and makes that context safely usable by people and bounded AI applications.
+CareOS is a clinician-first **interoperability, context and assurance layer** that sits beside existing hospital systems, composes source-linked clinical context and makes that context safely usable by people and bounded AI applications.
 
-[**▶ 90-sec Recare work sample**](https://mikelninh.github.io/recare/) · [**▶ One patient end to end**](https://mikelninh.github.io/careos/journey.html) · [**▶ Master plan**](https://mikelninh.github.io/careos/master.html) · [**▶ Synthetic study**](https://mikelninh.github.io/careos/study.html)
+[**▶ One patient end to end**](https://mikelninh.github.io/careos/journey.html) · [**▶ Synthetic study**](https://mikelninh.github.io/careos/study.html) · [**▶ Real-world proof plan**](proof/README.md)
 
 [![tests](https://github.com/mikelninh/care-os/actions/workflows/test.yml/badge.svg)](https://github.com/mikelninh/care-os/actions/workflows/test.yml)
-[![hospital-self-install](https://github.com/mikelninh/care-os/actions/workflows/hospital-self-install.yml/badge.svg)](https://github.com/mikelninh/care-os/actions/workflows/hospital-self-install.yml)
-[![future-foundation](https://github.com/mikelninh/care-os/actions/workflows/healthcare-future-foundation.yml/badge.svg)](https://github.com/mikelninh/care-os/actions/workflows/healthcare-future-foundation.yml)
 [![agent-redteam](https://github.com/mikelninh/care-os/actions/workflows/agent-redteam.yml/badge.svg)](https://github.com/mikelninh/care-os/actions/workflows/agent-redteam.yml)
 
-**Synthetic / pre-hospital research only · not for clinical use · no identifiable patient data in public demos · no production write-back**
+**Pre-hospital research · synthetic/deidentified evaluation only · not for clinical use · no production write-back**
 
 </div>
 
 ---
 
-## If you only have five minutes
-
-1. **Run the Recare work sample** — [Clinical Time-Back Challenge →](https://mikelninh.github.io/recare/)
-2. **See one complete patient journey** — [source → draft → outage → correction → recovery → patient → follow-up →](https://mikelninh.github.io/careos/journey.html)
-3. **Check what is actually implemented** — [Foundation status →](docs/FOUNDATION_IMPLEMENTATION_STATUS.md)
-4. **Check what is still unproven** — [Current gaps →](docs/CURRENT_STATUS_AND_GAPS.md)
-5. **For Recare specifically** — [Recare × CareOS collaboration map →](docs/RECARE_COLLABORATION_MAP.md)
-
-The intended reaction is not “nice AI demo.” It is:
-
-> **This person understands that healthcare AI only becomes useful when integration, clinical state, provenance, authority, failure behavior and human workflow all survive contact with reality.**
-
----
-
-## CareOS in 10 seconds
+## CareOS in 30 seconds
 
 Healthcare workers still act as human middleware between KIS/EHR, LIS, RIS/PACS, documents, ePA, calls, messages and legacy workflows.
 
@@ -56,15 +40,47 @@ KIS / EHR · LIS · RIS/PACS · documents · ePA
 
 Two questions drive the project:
 
-> **Clinical:** Can people spend less time hunting, reconciling, copying and coordinating information without losing provenance, uncertainty or human control?
+> **Clinical:** Can clinicians spend less time hunting, reconciling, copying and coordinating information without losing provenance, uncertainty or human control?
 
-> **Infrastructure:** Can hospital #100 inherit integration and safety knowledge learned from hospitals #1–99 instead of starting another bespoke IT project?
+> **Infrastructure:** Can hospital #100 reuse integration and safety knowledge learned from hospitals #1–99 instead of starting another bespoke IT project?
 
 North star: **Time Returned to Care — safety gated.**
 
+## Try these first
+
+1. **One complete synthetic patient journey** — [source → draft → outage → correction → recovery → patient → follow-up](https://mikelninh.github.io/careos/journey.html)
+2. **Time Returned to Care study** — [synthetic paired-study surface](https://mikelninh.github.io/careos/study.html)
+3. **What is actually implemented** — [`FOUNDATION_IMPLEMENTATION_STATUS.md`](docs/FOUNDATION_IMPLEMENTATION_STATUS.md)
+4. **What is still unproven** — [`CURRENT_STATUS_AND_GAPS.md`](docs/CURRENT_STATUS_AND_GAPS.md)
+5. **How we now create real evidence** — [`proof/README.md`](proof/README.md)
+
+The intended reaction is not “nice AI demo.” It is:
+
+> **Does this architecture and workflow survive real clinicians, real hospital systems and skeptical external review?**
+
 ---
 
-## Four invariants
+# What exists today
+
+| Area | Evidence state today |
+|---|---|
+| Source-linked clinical lifecycle/provenance | **tested synthetically** |
+| Patient-local graph + stale-artifact invalidation | **implemented + tested** |
+| Bounded agent/tool authority | **tested synthetically + adversarial scenarios** |
+| NORMAL / DEGRADED / OFFLINE / RECOVERY behavior | **implemented + tested synthetically** |
+| Patient/family source-linked experience | **implemented synthetically** |
+| FHIR R4 read path | **implemented research runtime** |
+| ISiK/FHIR-oriented validation path | **implemented research path** |
+| HL7 v2 ADT/ORU parsing | **synthetic/deidentified library connector** |
+| Hospital manifest / preflight / review pack | **implemented + tested, non-live** |
+| Docker/Helm deployment scaffold | **implemented, non-live** |
+| Time Returned to Care study machinery | **implemented — participant evidence pending** |
+| Real KIS/LIS integration | **external evidence required** |
+| Production PHI operations | **blocked by design** |
+| Multi-hospital repeatability | **not yet evidenced** |
+| Clinical/regulatory assurance | **external review required** |
+
+## Four correctness invariants
 
 | | Rule |
 |---|---|
@@ -73,20 +89,112 @@ North star: **Time Returned to Care — safety gated.**
 | **03** | **Documented therapy ≠ AI recommendation.** |
 | **04** | **Agent draft ≠ source truth.** |
 
-These are correctness constraints, not interface copy.
+The model may propose structure. It does **not** become the authority that creates trusted clinical truth.
 
 ---
 
-# One golden journey connects the whole foundation
+# The blocker we do not hide
+
+The frozen 500-case synthetic clinical-truth holdout currently preserves precision/provenance but achieves only **26.32% recall with 100% review-case burden**.
+
+Therefore **production G1 remains blocked**.
+
+That is not a footnote. It means CareOS should not be presented as clinically validated, production-ready or ready to make patient-care decisions.
+
+The correct next move is not to hide the result or tune against the frozen holdout. It is to improve the frontier on fresh development data, observe real user behavior, and test against real source variation.
+
+See [`CLAIM_EVIDENCE_MATRIX.md`](docs/CLAIM_EVIDENCE_MATRIX.md) and [`GATES.md`](docs/GATES.md).
+
+---
+
+# Real-World Proof Sprint 1
+
+CareOS has reached the point where **external evidence is more valuable than another broad feature**.
+
+The current proof ladder is:
+
+```text
+runnable synthetic tests
+        ↓
+real clinicians on synthetic cases
+        ↓
+independent clinical / privacy / security / IT critique
+        ↓
+real non-secret hospital capability manifest
+        ↓
+approved vendor / deidentified sandbox
+        ↓
+governed shadow workflow
+        ↓
+bounded read-only pilot
+        ↓
+second hospital / second vendor
+        ↓
+prove repeatability
+```
+
+Sprint 1 only graduates when we have:
+
+- **≥5 complete safe paired clinician sessions** for one workflow family;
+- observed baseline vs CareOS timing, errors, source checks and cognitive effort;
+- zero hidden safety-stop events in any positive result;
+- at least **3 independent reviewer perspectives**;
+- one real non-secret hospital capability manifest completed with hospital staff;
+- every external finding recorded as **supported / falsified / blocked / unknown**;
+- at least one assumption corrected or falsified.
+
+If nothing changes after external review, the test was probably too friendly.
+
+Start here:
+
+- [`proof/README.md`](proof/README.md)
+- [`proof/CLINICIAN_STUDY_PREREG.md`](proof/CLINICIAN_STUDY_PREREG.md)
+- [`proof/HOSPITAL_DISCOVERY_WORKSHOP.md`](proof/HOSPITAL_DISCOVERY_WORKSHOP.md)
+- [`proof/INDEPENDENT_REVIEW_PACKET.md`](proof/INDEPENDENT_REVIEW_PACKET.md)
+- [`proof/EVIDENCE_LEDGER.yaml`](proof/EVIDENCE_LEDGER.yaml)
+
+---
+
+# First workflow to prove
+
+**Physician morning review + documentation preparation.**
+
+The question is not:
+
+> “Do you like CareOS?”
+
+It is:
+
+> **Can a clinician reconstruct changed, pending and critical context and prepare the bounded documentation task faster or with less friction without more errors or verification collapse?**
+
+The paired protocol captures:
+
+- elapsed task time;
+- systems/searches/context switches;
+- wrong answers;
+- missed pending items;
+- source opens;
+- corrections;
+- acceptance without source verification;
+- cognitive effort;
+- explicit safety stops.
+
+A speed gain is **not** a win if safety or verification gets worse.
+
+Protocol: [`TIME_RETURNED_TO_CARE_STUDY.md`](docs/TIME_RETURNED_TO_CARE_STUDY.md) · facilitator test: [`CLINICIAN_TEST.md`](CLINICIAN_TEST.md)
+
+---
+
+# One golden journey protects the architecture
 
 `app/end_to_end_journey.py` is a permanent synthetic regression story:
 
 ```text
-source-linked preliminary result
+preliminary source result
         ↓
-patient-local clinical graph
+source-linked patient context
         ↓
-unsigned source-dependent draft
+unsigned derived draft
         ↓
 source/network interruption
         ↓
@@ -94,62 +202,22 @@ corrected/final result arrives
         ↓
 RECOVERY — reconcile before resuming
         ↓
-new fact supersedes old fact
+old derived work becomes REVIEW REQUIRED
         ↓
-dependent draft becomes REVIEW REQUIRED
-        ↓
-safety audit event
+human review + audit
         ↓
 NORMAL only after reconciliation
         ↓
 patient sees pending / next-step context
         ↓
-minimum-purpose follow-up request
-        ↓
-requested → received → accepted → scheduled
-→ performed → result available → follow-up complete
+follow-up request lifecycle
 ```
 
-[**View the human-readable golden journey →**](https://mikelninh.github.io/careos/journey.html)
-
-The regression deliberately protects two claim boundaries:
-
-- **Time Returned to Care is a target to measure, not a fabricated outcome.**
-- **24/7 production SLA is not offered until staffing and target-environment evidence exist.**
+[View the human-readable journey →](https://mikelninh.github.io/careos/journey.html)
 
 ---
 
-# What is implemented now
-
-## Clinical truth + lifecycle
-
-Consequential facts can retain:
-
-```text
-patient / encounter
-source organisation / system / resource
-original value / wording
-effective + recorded time
-version + freshness
-preliminary / final / corrected / cancelled
-pending / stale / unavailable / contradictory
-terminology mapping lineage
-review / supersession state
-```
-
-The model may propose structure. It does **not** become the authority that creates trusted clinical truth.
-
-Known blocker: the frozen 500-case synthetic holdout preserved precision/provenance but reached only **26.32% recall with 100% review-case burden**, so production G1 remains blocked.
-
-## Patient-local graph + stale-artifact invalidation
-
-- hard patient partition;
-- source / supersession / contradiction / derived relationships;
-- evidence + transformer/version lineage;
-- changed source facts reopen dependent unsigned AI/derived artifacts;
-- signed human artifacts are flagged, never silently rewritten.
-
-## Bounded agent architecture
+# Agent safety model
 
 ```text
 untrusted model proposal
@@ -168,49 +236,13 @@ human review
 
 Hostile scenarios include wrong patient, prompt injection, unavailable source, stale result and unauthorised write escalation.
 
-## Resilience + recovery
+The model cannot grant itself new patient, tool, operation or effect authority.
 
-Explicit modes:
-
-```text
-NORMAL · DEGRADED · OFFLINE · RECOVERY
-```
-
-Connectivity returning is not sufficient for normal operation: missed versions/events reconcile first, and corrected source facts can invalidate downstream drafts before the system returns to `NORMAL`.
-
-## Patient / family foundation
-
-The patient view uses the same source philosophy but answers different questions:
-
-```text
-What happened?
-What changed?
-What is still pending?
-Who owns the next step?
-What happens next?
-What medication changed?
-Where is the source?
-How can I flag a possible error?
-```
-
-Plain language is presentation metadata, not source mutation. Proxy access is an explicit revocable grant, not a shared password.
-
-[Try the synthetic patient view →](https://mikelninh.github.io/careos/patient.html)
-
-## Cross-provider care coordination
-
-A referral/transfer is modeled as workflow state rather than “document sent”:
-
-```text
-draft → requested → received → accepted/declined
-→ scheduled → performed → result available → follow-up complete
-```
-
-Agents may prepare. Initial sending requires governed human/workflow authority. Real KIM/FHIR/network transport remains external work.
+See [`AGENT_SECURITY_MODEL.md`](docs/AGENT_SECURITY_MODEL.md).
 
 ---
 
-# Hospital installation should be simple; approval should not be fake
+# Hospital integration: runnable scaffold, not fake compatibility
 
 Current command surface:
 
@@ -225,226 +257,104 @@ careos upgrade-check
 careos down
 ```
 
-Example:
-
-```bash
-git clone https://github.com/mikelninh/care-os.git
-cd care-os
-python -m venv .venv
-source .venv/bin/activate   # Windows: .venv\Scripts\activate
-pip install -r requirements.lock
-
-python scripts/careos.py init \
-  --hospital-id DE-DEMO-001 \
-  --site-name "Example Hospital"
-
-python scripts/careos.py doctor hospital.json --env-file deploy/hospital.env.example
-python scripts/careos.py preflight hospital.json
-python scripts/careos.py review-pack hospital.json --out-dir /tmp/careos-review
-python scripts/careos.py discover-fhir hospital.json --env-file deploy/hospital.env.example
-python scripts/careos.py up hospital.json --env-file deploy/hospital.env.example
-```
-
 The installer blocks rather than inventing missing patient identity, ownership, adapter runtime or live-data authority.
 
-### Adapter truth today
+Current adapter truth:
 
-| Path | Current CareOS state |
+| Path | Current state |
 |---|---|
-| **FHIR R4 read** | **implemented research runtime** |
-| **ISiK / FHIR read** | **FHIR runtime + ISiK validation path** |
-| **HL7 v2 ADT/ORU parsing** | **implemented synthetic/deidentified library connector** |
-| **HL7 v2 self-install transport / real interface engine** | **not runnable / real evidence required** |
-| Vendor API | **contract only** |
-| Document/source feed | **contract only** |
-| UI / computer-use bridge | **contract only** |
+| FHIR R4 read | implemented research runtime |
+| ISiK / FHIR read | runtime + validation path |
+| HL7 v2 ADT/ORU parsing | synthetic/deidentified library connector |
+| HL7 v2 real interface-engine transport | **real evidence required** |
+| Vendor API | contract only |
+| Document/source feed | contract only |
 | Live transactional/write | **blocked by release policy** |
 
-The machine-readable deployment catalog remains [`architecture/adapter-catalog.json`](architecture/adapter-catalog.json). It intentionally does **not** advertise a green HL7 self-install path until transport/interface-engine and real compatibility evidence exist.
+No named KIS/LIS compatibility claim is made until a real approved sandbox or hospital environment provides that evidence.
 
 ---
 
-# Hospital-scale reuse foundation
+# Where OpenAction fits
 
-The infrastructure hypothesis is now executable as contracts:
+CareOS is the **clinical product and source-linked workflow layer**.
 
-### Trusted MPI / source-ID resolution
-
-An enterprise patient may map deterministically to different source IDs. Missing, ambiguous, unavailable or stale resolution fails closed before connector reads. No LLM performs patient matching.
-
-The runtime contract exists; `careos doctor/up` still block trusted-MPI self-install until an approved real hospital resolver adapter is configured.
-
-### Generated hospital review pack
-
-`careos review-pack` produces non-secret JSON / Markdown / Mermaid describing systems, adapters, auth modes, data flow, owner lanes, read/write boundaries and unresolved blockers.
-
-It supports DPO/CISO/IT review. It is **not** DSFA/DPIA/security approval.
-
-### Evidence-gated canary + rollback
+[OpenAction](https://github.com/mikelninh/openaction) is the **adoption/evidence coordination layer** around the real pilot:
 
 ```text
-PROPOSED → PREFLIGHT → CONFORMANCE → CANARY
-                                   ↙      ↘
-                              ROLLBACK   PROMOTE
+claim
+  ↓
+required evidence
+  ↓
+owner
+  ↓
+independent verifier
+  ↓
+verified / rejected / blocked
+  ↓
+next milestone unlocked
 ```
 
-Identity errors, incomplete reads, unsupported claims, safety stops, operator stop or unexpected write authority block promotion.
+For a CareOS hospital pilot, OpenAction can coordinate Clinical, Privacy, Security, Integration, Procurement, Finance, Operations and Sponsor while keeping one shared case state.
 
-### Compatibility registry
+That creates a second falsifiable question:
 
-Vendor/product/version evidence can be classified as:
-
-```text
-synthetic-only · real-sandbox · real-shadow · production-observed
-```
-
-Compatibility knowledge can reduce repeated investigation. It can never automatically approve rollout.
-
-[Hospital-scale foundation →](docs/HOSPITAL_SCALE_FOUNDATION.md)
+> **Can we reduce avoidable waiting and duplicate review work without reducing accountability?**
 
 ---
 
-# Measure usefulness instead of admiring the demo
+# What we do not claim
 
-The Time Returned to Care study captures:
+CareOS is **not currently**:
 
-- elapsed time;
-- systems/searches/context switches;
-- copy/paste;
-- clarification contacts;
-- wrong answers;
-- missed pending items;
-- source opens;
-- corrections;
-- acceptance without source verification;
-- cognitive effort;
-- explicit safety stops.
+- clinically validated;
+- approved for identifiable patient-data production use;
+- proven to save clinician time;
+- proven interoperable with a named production KIS/LIS;
+- a production-ready generic HL7 v2 interface-engine integration;
+- proven repeatable across hospitals;
+- regulatory approved/certified;
+- a 24/7 clinical service.
 
-The paired protocol now counterbalances **condition order and matched synthetic case variant**. A role result is not marked publishable before ≥5 complete safe pairs, both order directions are represented and no safety/verification gate fails.
-
-[Run the synthetic study →](https://mikelninh.github.io/careos/study.html) · [Protocol →](docs/TIME_RETURNED_TO_CARE_STUDY.md)
+Stronger-looking copy is not stronger evidence.
 
 ---
 
-# Evidence state — not a self-score
+# How to help
 
-| Area | Current evidence state |
-|---|---|
-| Clinician workflow | **DEMONSTRATED SYNTHETICALLY** |
-| Clinical truth / provenance | **DEMONSTRATED SYNTHETICALLY — G1 BLOCKED** |
-| Graph / stale-artifact invalidation | **IMPLEMENTED + TESTED** |
-| Agent containment / adversarial evals | **DEMONSTRATED SYNTHETICALLY** |
-| Resilience / recovery | **IMPLEMENTED + TESTED SYNTHETICALLY** |
-| Patient/family experience | **IMPLEMENTED SYNTHETICALLY — usability pending** |
-| Cross-provider lifecycle | **IMPLEMENTED CONTRACT — real transport pending** |
-| Hospital manifest / preflight / local FHIR data plane | **IMPLEMENTED — NON-LIVE** |
-| Trusted MPI resolver contract | **IMPLEMENTED — real resolver integration pending** |
-| Review-pack / rollout / compatibility registry | **IMPLEMENTED + SYNTHETICALLY TESTED** |
-| HL7 v2 ADT/ORU library connector | **IMPLEMENTED SYNTHETICALLY — transport/vendor evidence pending** |
-| Time Returned to Care machinery | **IMPLEMENTED — participant evidence pending** |
-| Real KIS/LIS integration | **EXTERNAL EVIDENCE REQUIRED** |
-| Production PHI operations | **BLOCKED BY DESIGN** |
-| Multi-hospital repeatability | **NOT YET EVIDENCED** |
-| Regulatory / independent assurance | **EXTERNAL REVIEW REQUIRED** |
+The highest-value contribution now is **skeptical external evidence**, not more speculative features.
 
-[Canonical implementation status →](docs/FOUNDATION_IMPLEMENTATION_STATUS.md) · [Gap register →](docs/CURRENT_STATUS_AND_GAPS.md) · [Production gates →](docs/GATES.md)
+### If you are a clinician
+Run one paired synthetic workflow and tell us where the workflow or trust model fails.
+
+### If you work in hospital IT / integration
+Try to map CareOS against a real non-secret system landscape and identify assumptions that do not survive your KIS/LIS/MPI reality.
+
+### If you work in privacy / security / clinical safety / regulatory
+Use the [`Independent Review Packet`](proof/INDEPENDENT_REVIEW_PACKET.md) and try to block the next step for a good reason.
+
+### If you work in UX / service design
+Test whether a clinician can understand changed/pending/source state without explanation and whether verification feels easier rather than heavier.
+
+Every meaningful external finding should end up in the evidence ledger or as a regression test.
 
 ---
 
-# Recare: collaboration, not duplication
-
-Recare already operates the real hospital product/integration layer. CareOS is not a proposal to replace it.
-
-The useful question is:
-
-> **Which CareOS invariants, evals and integration patterns survive Recare's production reality — and where could they make an existing hospital platform easier to scale or safer to change?**
-
-Areas to validate with the team:
-
-- clinical lifecycle semantics across heterogeneous sources;
-- provenance survival through context → agent/document → human review;
-- agent tool/authority containment;
-- failure replay/evaluation;
-- integration knowledge as machine-readable compatibility/conformance evidence;
-- upgrade regression testing;
-- Time Returned to Care without verification decay.
-
-We do **not** assume Recare lacks these internally.
-
-[Recare × CareOS Collaboration Map →](docs/RECARE_COLLABORATION_MAP.md)
-
----
-
-# Endgame
-
-The endgame is **not one world EHR**.
-
-It is an open clinical interoperability fabric where hospitals can keep/change systems of record while applications integrate against stable trustworthy seams:
-
-```text
-FHIR / IPS / provenance / trust
-        ↓
-regional + national profiles
-        ↓
-open adapters + conformance
-        ↓
-provider-local data planes
-        ↓
-stable source-linked context contract
-        ↓
-clinician / patient / agent / app ecosystem
-```
-
-Success eventually means a hospital can change a KIS vendor without rebuilding every application integration, and a new compatible application does not need 80 hospital-specific pipelines.
-
-[Read the endgame →](docs/ENDGAME.md) · [Healthcare Future Master Plan →](docs/HEALTHCARE_FUTURE_MASTER_PLAN.md)
-
----
-
-# What happens next
-
-```text
-real synthetic participant sessions
-        ↓
-Recare / production-engineering critique
-        ↓
-real hospital workflow archaeology
-        ↓
-first real capability manifest
-        ↓
-approved deidentified KIS/LIS/vendor sandbox
-        ↓
-shadow workflow
-        ↓
-read-only pilot
-        ↓
-second vendor / second hospital
-        ↓
-prove repeatability
-```
-
-Broad speculative feature expansion is now lower value than external evidence.
-
----
-
-## Deep review
+# Deep review
 
 | Need | Start here |
 |---|---|
-| Whole future state | [Healthcare Future Master Plan](docs/HEALTHCARE_FUTURE_MASTER_PLAN.md) |
-| Current implementation | [Foundation Implementation Status](docs/FOUNDATION_IMPLEMENTATION_STATUS.md) |
-| Current gaps | [Status & Gap Register](docs/CURRENT_STATUS_AND_GAPS.md) |
-| Infrastructure endgame | [CareOS Endgame](docs/ENDGAME.md) |
-| Hospital install / scale | [Self-Install Platform](docs/HOSPITAL_SELF_INSTALL_PLATFORM.md) |
-| Hospital scale contracts | [Hospital-Scale Foundation](docs/HOSPITAL_SCALE_FOUNDATION.md) |
-| Hospital rollout | [Implementation Playbook](docs/HOSPITAL_IMPLEMENTATION_PLAYBOOK.md) |
-| Architecture | [Architecture V2](docs/ARCHITECTURE_V2.md) |
-| Agent security | [Agent Security Model](docs/AGENT_SECURITY_MODEL.md) |
-| Patient / family | [Patient & Family Experience](docs/PATIENT_FAMILY_EXPERIENCE.md) |
-| Critical operations | [Critical Service Operating Model](docs/CRITICAL_SERVICE_OPERATING_MODEL.md) |
-| Germany → world | [Global Interoperability Blueprint](docs/GERMANY_GLOBAL_HEALTH_INTEROP_BLUEPRINT.md) |
-| Recare collaboration | [Recare Collaboration Map](docs/RECARE_COLLABORATION_MAP.md) |
-| Technical index | [Technical Documentation Index](docs/TECHNICAL_DOCUMENTATION_INDEX.md) |
+| Real-world proof campaign | [`proof/README.md`](proof/README.md) |
+| Claim → evidence matrix | [`CLAIM_EVIDENCE_MATRIX.md`](docs/CLAIM_EVIDENCE_MATRIX.md) |
+| Current gaps | [`CURRENT_STATUS_AND_GAPS.md`](docs/CURRENT_STATUS_AND_GAPS.md) |
+| Implementation status | [`FOUNDATION_IMPLEMENTATION_STATUS.md`](docs/FOUNDATION_IMPLEMENTATION_STATUS.md) |
+| Production gates | [`GATES.md`](docs/GATES.md) |
+| Architecture | [`ARCHITECTURE_V2.md`](docs/ARCHITECTURE_V2.md) |
+| Hospital rollout | [`HOSPITAL_IMPLEMENTATION_PLAYBOOK.md`](docs/HOSPITAL_IMPLEMENTATION_PLAYBOOK.md) |
+| Hospital scale | [`HOSPITAL_SCALE_FOUNDATION.md`](docs/HOSPITAL_SCALE_FOUNDATION.md) |
+| Agent security | [`AGENT_SECURITY_MODEL.md`](docs/AGENT_SECURITY_MODEL.md) |
+| Patient / family | [`PATIENT_FAMILY_EXPERIENCE.md`](docs/PATIENT_FAMILY_EXPERIENCE.md) |
+| Endgame | [`ENDGAME.md`](docs/ENDGAME.md) |
 
 ---
 


### PR DESCRIPTION
## Goal
Make CareOS easier to share with clinicians, UX/product reviewers, hospital IT and external collaborators without weakening evidence boundaries.

## Changes
- shorten the first-minute explanation
- move real-world proof sprint to the front
- keep the 26.32% recall / 100% review-burden G1 blocker prominent
- distinguish what is implemented from what still needs external evidence
- connect CareOS to OpenAction as the adoption/evidence layer
- add clear contribution paths for clinicians, hospital IT, assurance and UX reviewers

No clinical-use claim or live-data permission is added.