### PR TITLE
docs: make CareOS release assurance explicit

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 CareOS is a clinician-first **interoperability, context and assurance layer** that sits beside existing hospital systems, composes source-linked clinical context and makes that context safely usable by people and bounded AI applications.
 
-[**▶ One patient end to end**](https://mikelninh.github.io/careos/journey.html) · [**▶ Synthetic study**](https://mikelninh.github.io/careos/study.html) · [**▶ Real-world proof plan**](proof/README.md)
+[**▶ Clinical review demo**](https://mikelninh.github.io/careos/clinical.html) · [**▶ One patient end to end**](https://mikelninh.github.io/careos/journey.html) · [**▶ Synthetic study**](https://mikelninh.github.io/careos/study.html) · [**▶ Release assurance**](docs/RELEASE_ASSURANCE.md) · [**▶ Real-world proof plan**](proof/README.md)
 
 [![tests](https://github.com/mikelninh/care-os/actions/workflows/test.yml/badge.svg)](https://github.com/mikelninh/care-os/actions/workflows/test.yml)
 [![agent-redteam](https://github.com/mikelninh/care-os/actions/workflows/agent-redteam.yml/badge.svg)](https://github.com/mikelninh/care-os/actions/workflows/agent-redteam.yml)
@@ -48,11 +48,13 @@ North star: **Time Returned to Care — safety gated.**
 
 ## Try these first
 
-1. **One complete synthetic patient journey** — [source → draft → outage → correction → recovery → patient → follow-up](https://mikelninh.github.io/careos/journey.html)
-2. **Time Returned to Care study** — [synthetic paired-study surface](https://mikelninh.github.io/careos/study.html)
-3. **What is actually implemented** — [`FOUNDATION_IMPLEMENTATION_STATUS.md`](docs/FOUNDATION_IMPLEMENTATION_STATUS.md)
-4. **What is still unproven** — [`CURRENT_STATUS_AND_GAPS.md`](docs/CURRENT_STATUS_AND_GAPS.md)
-5. **How we now create real evidence** — [`proof/README.md`](proof/README.md)
+1. **Interactive clinical review** — [source review → human status review → documentation → ready-for-transfer](https://mikelninh.github.io/careos/clinical.html)
+2. **One complete synthetic patient journey** — [source → draft → outage → correction → recovery → patient → follow-up](https://mikelninh.github.io/careos/journey.html)
+3. **Time Returned to Care study** — [synthetic paired-study surface](https://mikelninh.github.io/careos/study.html)
+4. **What is actually implemented** — [`FOUNDATION_IMPLEMENTATION_STATUS.md`](docs/FOUNDATION_IMPLEMENTATION_STATUS.md)
+5. **What is automatically tested vs externally unproven** — [`RELEASE_ASSURANCE.md`](docs/RELEASE_ASSURANCE.md)
+6. **What is still unproven** — [`CURRENT_STATUS_AND_GAPS.md`](docs/CURRENT_STATUS_AND_GAPS.md)
+7. **How we now create real evidence** — [`proof/README.md`](proof/README.md)
 
 The intended reaction is not “nice AI demo.” It is:
 
@@ -69,6 +71,7 @@ The intended reaction is not “nice AI demo.” It is:
 | Bounded agent/tool authority | **tested synthetically + adversarial scenarios** |
 | NORMAL / DEGRADED / OFFLINE / RECOVERY behavior | **implemented + tested synthetically** |
 | Patient/family source-linked experience | **implemented synthetically** |
+| Human clinical review UX | **interactive synthetic demo + DOM smoke + desktop/mobile visual QA** |
 | FHIR R4 read path | **implemented research runtime** |
 | ISiK/FHIR-oriented validation path | **implemented research path** |
 | HL7 v2 ADT/ORU parsing | **synthetic/deidentified library connector** |
@@ -90,6 +93,12 @@ The intended reaction is not “nice AI demo.” It is:
 | **04** | **Agent draft ≠ source truth.** |
 
 The model may propose structure. It does **not** become the authority that creates trusted clinical truth.
+
+## Release assurance in one sentence
+
+CareOS has strong **synthetic engineering E2E + adversarial + integration-path coverage**, but it does **not** have clinical-production E2E proof. A green repository cannot substitute for real clinicians, approved hospital environments, privacy/security review or regulatory evidence.
+
+See [`RELEASE_ASSURANCE.md`](docs/RELEASE_ASSURANCE.md) for the exact automated layers and non-claims.
 
 ---
 
@@ -344,6 +353,7 @@ Every meaningful external finding should end up in the evidence ledger or as a r
 
 | Need | Start here |
 |---|---|
+| Release assurance / automated vs external proof | [`RELEASE_ASSURANCE.md`](docs/RELEASE_ASSURANCE.md) |
 | Real-world proof campaign | [`proof/README.md`](proof/README.md) |
 | Claim → evidence matrix | [`CLAIM_EVIDENCE_MATRIX.md`](docs/CLAIM_EVIDENCE_MATRIX.md) |
 | Current gaps | [`CURRENT_STATUS_AND_GAPS.md`](docs/CURRENT_STATUS_AND_GAPS.md) |

--- a/docs/RELEASE_ASSURANCE.md
+++ b/docs/RELEASE_ASSURANCE.md
@@ -1,0 +1,87 @@
+# CareOS Release Assurance
+
+This document separates **what the repository exercises automatically** from what still requires external clinical, hospital, privacy, security or regulatory evidence.
+
+CareOS is a pre-hospital research system. Passing this matrix is an engineering gate, **not clinical validation or authorization for production PHI**.
+
+## Assurance layers
+
+| Layer | Current evidence | Meaning |
+|---|---|---|
+| Golden clinical lifecycle | `app/end_to_end_journey.py` + regression tests | preliminary → source-linked context → draft → outage → correction → recovery/reconciliation → stale derived work → human review/audit |
+| Clinical state semantics | automated tests | pending ≠ negative; unavailable ≠ absent; documented therapy ≠ AI recommendation; agent draft ≠ source truth |
+| Patient identity / isolation | access-policy, gateway, graph and red-team tests | wrong-patient and cross-context access must fail closed |
+| Agent authority | agent gateway/policy/delegation/hijacking/red-team suites | model cannot grant itself patient, tool, operation or write authority |
+| Provenance / stale state | graph/lifecycle/invalidation tests | source corrections invalidate or flag derived work rather than silently preserving it |
+| Degraded/offline/recovery | runtime and recovery scenarios | normal operation may resume only after reconciliation |
+| FHIR / ISiK / HL7 research paths | integration/validation workflows | research compatibility paths are executable; named production-vendor compatibility is not claimed |
+| Security/static analysis | CodeQL + platform/agent red-team workflows | code and authority boundaries receive automated adversarial/static checks |
+| Public clinical UX demo | portfolio DOM smoke + manual desktop/mobile visual QA | source review → human status review → documentation preparation → documentation review → ready-for-transfer; conflicts block release |
+| Frozen clinical-truth holdout | scheduled G1 benchmark | current 500-case holdout remains a blocker, not a marketing metric |
+
+## Public interactive demo
+
+<https://mikelninh.github.io/careos/clinical.html>
+
+The public demo uses synthetic data and demonstrates the human-review workflow. It does **not** write to a KIS/PVS, recommend treatment or imply clinical validation.
+
+The demo deliberately contains negative paths:
+
+- a pending result remains pending rather than becoming negative;
+- conflicting discharge information blocks release until human clarification;
+- documentation can be prepared and reviewed, but the demo only marks it **ready for transfer** — it does not perform a production write.
+
+## Adversarial / edge-case families
+
+The repository includes automated coverage for scenarios such as:
+
+- wrong patient / wrong encounter;
+- prompt injection and agent hijacking;
+- unavailable source;
+- stale/corrected source result;
+- unauthorized write escalation;
+- bounded delegation and tool access;
+- provenance and patient-local graph integrity;
+- degraded/offline/recovery transitions;
+- reconciliation before returning to NORMAL.
+
+See the test suite and workflows rather than treating this list as a completeness claim.
+
+## CI entry points
+
+Key workflows include:
+
+- `.github/workflows/test.yml`
+- `.github/workflows/container-smoke.yml`
+- `.github/workflows/codeql.yml`
+- `.github/workflows/agent-redteam.yml`
+- `.github/workflows/platform-redteam.yml`
+- `.github/workflows/fhir-integration.yml`
+- `.github/workflows/isik5-validation.yml`
+- `.github/workflows/g1-dev.yml`
+- `.github/workflows/g1-holdout3.yml`
+- `.github/workflows/hospital-self-install.yml`
+
+## Known blocker
+
+The frozen 500-case synthetic clinical-truth holdout currently reports **26.32% recall with 100% review-case burden**. Production G1 therefore remains blocked.
+
+Do not tune against the frozen holdout just to improve the public number. Improvements belong on fresh development data, then the holdout is used as an independent gate.
+
+## What engineering E2E does not prove
+
+Even a completely green repository does **not** prove:
+
+- clinical safety in real patient care;
+- real clinician time savings;
+- production KIS/LIS interoperability;
+- lawful/approved PHI operation in a hospital;
+- medical-device or other regulatory status;
+- multi-hospital repeatability;
+- 24/7 operational reliability.
+
+Those require real clinicians, approved/deidentified vendor environments, hospital IT/security/privacy review, governed shadow workflows and eventually bounded production pilots.
+
+## Release rule
+
+A claim may only move from **implemented** to **proven** when the evidence type matches the claim. Synthetic engineering evidence can unblock engineering work; it cannot silently substitute for clinical or institutional evidence.


### PR DESCRIPTION
Documentation hardening after the clinical-review demo shipped.

Adds:
- direct README link to the interactive clinical review demo
- explicit distinction between synthetic engineering E2E and clinical-production proof
- `docs/RELEASE_ASSURANCE.md` mapping golden journey, state invariants, identity/agent/red-team/integration coverage and external evidence gaps
- public demo negative-path description (pending stays pending, conflicts block release, no KIS/PVS write)

No production-readiness claim is added; the current holdout blocker remains prominent.