### PR TITLE
CareOS: OpenProof Trust Passport MVP

### DIFF
--- a/.github/workflows/openproof-trust-passport.yml
+++ b/.github/workflows/openproof-trust-passport.yml
@@ -1,0 +1,26 @@
+name: CareOS OpenProof Trust Passport
+on:
+  pull_request:
+    paths:
+      - 'app/openproof_trust_passport.py'
+      - 'tests/test_openproof_trust_passport.py'
+      - 'docs/OPENPROOF_TRUST_PASSPORT.md'
+      - '.github/workflows/openproof-trust-passport.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'app/openproof_trust_passport.py'
+      - 'tests/test_openproof_trust_passport.py'
+      - '.github/workflows/openproof-trust-passport.yml'
+permissions:
+  contents: read
+jobs:
+  trust-passport:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - run: python -m pip install pytest
+      - run: python -m pytest -q tests/test_openproof_trust_passport.py

--- a/app/openproof_trust_passport.py
+++ b/app/openproof_trust_passport.py
@@ -1,0 +1,113 @@
+"""CareOS × OpenProof Trust Passport MVP.
+
+The passport proves bounded trust/readiness predicates. It must not carry raw
+clinical data and it never becomes a clinical decision or source of truth.
+
+`careos-trust-local-v0` is a local commitment/predicate backend for integration
+and leakage tests. Production proof claims require issuer-bound credentials and
+Midnight/Compact ZK verification.
+"""
+from __future__ import annotations
+
+from hashlib import sha256
+import json
+from typing import Any
+
+OPENPROOF_VERSION = "openproof/0.1"
+PURPOSE = "careos.trust-passport"
+BACKEND = "careos-trust-local-v0"
+
+
+def _canonical(value: Any) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+
+
+def _digest(value: str) -> str:
+    return sha256(value.encode("utf-8")).hexdigest()
+
+
+def create_trust_passport(
+    private_trust: dict[str, Any],
+    *,
+    scope: dict[str, Any],
+    nonce: str,
+    current_day: int,
+) -> dict[str, Any]:
+    """Create a public trust projection with no PHI/raw credential disclosure."""
+    if not nonce:
+        raise ValueError("nonce required")
+    if not scope.get("hospital") or not scope.get("workflow"):
+        raise ValueError("hospital and workflow scope required")
+
+    predicates = [
+        {"id": "licence_active", "claim": "professional.licence_active", "op": "eq_true", "passed": private_trust.get("professional", {}).get("licence_active") is True},
+        {"id": "role_authorised", "claim": "professional.role_authorised", "op": "eq_true", "passed": private_trust.get("professional", {}).get("role_authorised") is True},
+        {"id": "consent_valid", "claim": "governance.consent_valid", "op": "eq_true", "passed": private_trust.get("governance", {}).get("consent_valid") is True},
+        {"id": "privacy_review_current", "claim": "governance.privacy_review_current", "op": "eq_true", "passed": private_trust.get("governance", {}).get("privacy_review_current") is True},
+        {"id": "security_review_current", "claim": "governance.security_review_current", "op": "eq_true", "passed": private_trust.get("governance", {}).get("security_review_current") is True},
+        {
+            "id": "credential_current",
+            "claim": "professional.valid_until_day",
+            "op": "gte",
+            "passed": isinstance(private_trust.get("professional", {}).get("valid_until_day"), int)
+            and private_trust["professional"]["valid_until_day"] >= current_day,
+        },
+    ]
+
+    private_witness = {"trust": private_trust, "scope": scope}
+    scope_hash = f"sha256:{_digest(_canonical(scope))}"
+    return {
+        "openproof": OPENPROOF_VERSION,
+        "backend": BACKEND,
+        "purpose": PURPOSE,
+        "subject": private_trust.get("subject_id", "anonymous-bounded-subject"),
+        "scope_hash": scope_hash,
+        "claims_commitment": f"sha256:{_digest(f'{_canonical(private_witness)}:{nonce}')}",
+        "predicate_results": predicates,
+        "disclosures": {},
+        "decision": "TRUST_CONDITIONS_MET" if all(x["passed"] for x in predicates) else "REVIEW_REQUIRED",
+        "clinical_boundary": "trust_passport_is_not_clinical_truth_or_clinical_approval",
+        "data_boundary": "no_patient_record_or_raw_clinical_data_in_proof",
+    }
+
+
+def verify_trust_passport(
+    proof: dict[str, Any],
+    *,
+    expected_scope_hash: str | None = None,
+) -> dict[str, Any]:
+    errors: list[str] = []
+    if proof.get("openproof") != OPENPROOF_VERSION:
+        errors.append("openproof version mismatch")
+    if proof.get("purpose") != PURPOSE:
+        errors.append("purpose mismatch")
+    if expected_scope_hash and proof.get("scope_hash") != expected_scope_hash:
+        errors.append("scope mismatch")
+    if proof.get("disclosures") not in ({}, None):
+        errors.append("trust passport must not disclose raw claims")
+    if not str(proof.get("claims_commitment", "")).startswith("sha256:"):
+        errors.append("claims commitment missing")
+    if proof.get("clinical_boundary") != "trust_passport_is_not_clinical_truth_or_clinical_approval":
+        errors.append("clinical authority boundary missing")
+    if proof.get("data_boundary") != "no_patient_record_or_raw_clinical_data_in_proof":
+        errors.append("clinical data boundary missing")
+
+    required = {
+        "licence_active",
+        "role_authorised",
+        "consent_valid",
+        "privacy_review_current",
+        "security_review_current",
+        "credential_current",
+    }
+    results = {item.get("id"): item for item in proof.get("predicate_results", [])}
+    missing = required - set(results)
+    if missing:
+        errors.append(f"missing predicates: {sorted(missing)}")
+    for predicate_id in required & set(results):
+        if results[predicate_id].get("passed") is not True:
+            errors.append(f"predicate failed: {predicate_id}")
+    if proof.get("decision") != "TRUST_CONDITIONS_MET":
+        errors.append("trust conditions not met")
+
+    return {"ok": not errors, "errors": errors}

--- a/docs/OPENPROOF_TRUST_PASSPORT.md
+++ b/docs/OPENPROOF_TRUST_PASSPORT.md
@@ -1,0 +1,91 @@
+# CareOS × OpenProof — Trust Passport MVP
+
+## Goal
+
+Prove a narrow set of workflow trust conditions without copying the underlying professional credentials, governance files or clinical context into every participating system.
+
+A Trust Passport answers:
+
+> **Are the declared trust conditions for this exact workflow currently satisfied?**
+
+It does **not** answer:
+
+- is a diagnosis correct?
+- is a treatment appropriate?
+- is this patient safe to discharge?
+- is this clinician universally authorised?
+- has a regulator approved CareOS?
+
+## Golden proof
+
+```text
+private professional + governance credentials
+        ↓
+OpenProof / future Midnight prover
+        ↓
+licence active              ✓
+role authorised             ✓
+required consent valid      ✓
+privacy review current      ✓
+security review current     ✓
+credential current          ✓
+        ↓
+workflow-bound Trust Passport
+        ↓
+CareOS policy gate / human review
+```
+
+No patient record, diagnosis, medication, note or raw credential document belongs in the public proof.
+
+## Current implementation
+
+`app/openproof_trust_passport.py` provides:
+
+- OpenProof `0.1` public envelope;
+- purpose binding (`careos.trust-passport`);
+- workflow/hospital scope commitment;
+- SHA-256 private-witness commitment;
+- six explicit trust predicates;
+- zero raw disclosures;
+- fail-closed verification;
+- explicit clinical-authority and data boundaries.
+
+`tests/test_openproof_trust_passport.py` checks:
+
+- positive synthetic trust state;
+- no leakage of clinician name, licence number, internal review notes or deliberately injected synthetic patient context;
+- missing consent -> `REVIEW_REQUIRED`;
+- expired credential -> reject;
+- different workflow scope -> reject;
+- any raw disclosure -> reject.
+
+The deliberately injected synthetic patient context in the test is a leakage canary only. **Production callers must not put PHI into the Trust Passport witness at all.**
+
+## Security truth
+
+`careos-trust-local-v0` is not a zero-knowledge backend. It is an integration and privacy-surface prototype that demonstrates the application can consume predicate proofs instead of raw credentials.
+
+Production should replace it with issuer-bound credentials and a Midnight Compact circuit that:
+
+1. verifies the credential issuer / attestation signature;
+2. binds the subject and exact workflow scope;
+3. evaluates trust predicates privately;
+4. binds expiry, policy version and replay protection;
+5. discloses only the minimum proof result;
+6. leaves clinical truth and clinical authority in their authoritative systems and humans.
+
+## PHI rule
+
+> **Midnight/OpenProof is a proof rail around CareOS, never the clinical record.**
+
+Patient data remains in approved clinical systems / governed CareOS context paths. A cryptographic proof may establish consent, role, credential freshness or approval state without moving the underlying record on-chain.
+
+## Graduation gates
+
+- compile/test the Compact predicate scaffold with the pinned Midnight toolchain;
+- add trusted issuer verification in-circuit;
+- prove no raw witness value reaches ledger/indexer-visible state;
+- add revocation + expiry + replay/nullifier tests;
+- bind approval receipts to exact workflow/scope/version;
+- independent privacy/security review;
+- clinician/hospital shadow testing with synthetic or approved deidentified data before any PHI production path.

--- a/tests/test_openproof_trust_passport.py
+++ b/tests/test_openproof_trust_passport.py
@@ -1,0 +1,104 @@
+import json
+
+from app.openproof_trust_passport import create_trust_passport, verify_trust_passport
+
+
+def synthetic_trust(**overrides):
+    trust = {
+        "subject_id": "clinician-synthetic-001",
+        "professional": {
+            "full_name": "Dr Synthetic",
+            "licence_number": "SYNTH-LIC-12345",
+            "licence_active": True,
+            "role_authorised": True,
+            "valid_until_day": 21000,
+        },
+        "governance": {
+            "consent_valid": True,
+            "privacy_review_current": True,
+            "security_review_current": True,
+            "internal_review_notes": "private governance note",
+        },
+        # Included only to prove the public projection does not leak arbitrary
+        # private witness fields. Production callers MUST NOT put PHI into a
+        # Trust Passport witness at all.
+        "forbidden_patient_context": {
+            "mrn": "MRN-SYNTH-999",
+            "diagnosis": "synthetic diagnosis",
+        },
+    }
+    for section, values in overrides.items():
+        trust[section] = {**trust.get(section, {}), **values}
+    return trust
+
+
+def scope():
+    return {"hospital": "synthetic-hospital", "workflow": "morning-review", "role": "physician"}
+
+
+def test_trust_passport_passes_without_leaking_raw_credentials_or_phi():
+    proof = create_trust_passport(
+        synthetic_trust(),
+        scope=scope(),
+        nonce="fixed-test-nonce",
+        current_day=20693,
+    )
+
+    public = json.dumps(proof, sort_keys=True)
+    assert "Dr Synthetic" not in public
+    assert "SYNTH-LIC-12345" not in public
+    assert "private governance note" not in public
+    assert "MRN-SYNTH-999" not in public
+    assert "synthetic diagnosis" not in public
+    assert proof["decision"] == "TRUST_CONDITIONS_MET"
+    assert verify_trust_passport(proof) == {"ok": True, "errors": []}
+
+
+def test_missing_consent_fails_closed():
+    proof = create_trust_passport(
+        synthetic_trust(governance={"consent_valid": False}),
+        scope=scope(),
+        nonce="n2",
+        current_day=20693,
+    )
+    result = verify_trust_passport(proof)
+    assert proof["decision"] == "REVIEW_REQUIRED"
+    assert result["ok"] is False
+    assert "predicate failed: consent_valid" in result["errors"]
+
+
+def test_expired_credential_fails_closed():
+    proof = create_trust_passport(
+        synthetic_trust(professional={"valid_until_day": 20000}),
+        scope=scope(),
+        nonce="n3",
+        current_day=20693,
+    )
+    result = verify_trust_passport(proof)
+    assert result["ok"] is False
+    assert "predicate failed: credential_current" in result["errors"]
+
+
+def test_scope_binding_prevents_cross_workflow_reuse():
+    proof = create_trust_passport(
+        synthetic_trust(),
+        scope=scope(),
+        nonce="n4",
+        current_day=20693,
+    )
+    result = verify_trust_passport(proof, expected_scope_hash="sha256:not-the-same-workflow")
+    assert result["ok"] is False
+    assert "scope mismatch" in result["errors"]
+
+
+def test_raw_disclosure_is_rejected():
+    proof = create_trust_passport(
+        synthetic_trust(),
+        scope=scope(),
+        nonce="n5",
+        current_day=20693,
+    )
+    proof["disclosures"] = {"professional.licence_number": "SYNTH-LIC-12345"}
+    result = verify_trust_passport(proof)
+    assert result["ok"] is False
+    assert "trust passport must not disclose raw claims" in result["errors"]


### PR DESCRIPTION
## Goal

Add the CareOS reference proof for bounded workflow trust conditions without copying raw professional credentials, governance files or clinical context into the receiving workflow.

## Implemented

- `app/openproof_trust_passport.py`
  - purpose and workflow-scope binding
  - private trust-state commitment
  - licence / role / consent / privacy / security / freshness predicates
  - zero raw disclosures
  - fail-closed verifier
  - explicit clinical-authority and clinical-data boundaries
- `tests/test_openproof_trust_passport.py`
  - positive synthetic trust state
  - no leakage of clinician name/licence/internal notes or synthetic PHI leakage canary
  - missing consent -> REVIEW_REQUIRED
  - expired credential -> reject
  - different workflow scope -> reject
  - any raw disclosure -> reject
- `docs/OPENPROOF_TRUST_PASSPORT.md`
- dedicated CI gate

## Truth boundary

`careos-trust-local-v0` is not a zero-knowledge backend. It is an integration/privacy-surface prototype.

A Trust Passport is not clinical truth, not regulatory approval and not a medical decision. Patient data remains in approved clinical systems/governed CareOS paths; OpenProof is a proof rail around those systems, never the clinical record.

The production target is an issuer-bound Midnight/Compact proof that reveals only the minimum workflow trust result.

## Next gates

- compile/test Compact scaffold with pinned toolchain
- trusted issuer verification in-circuit
- expiry/revocation/replay protection
- exact scope/policy-version binding
- verify no raw witness values are ledger/indexer-visible
- independent privacy/security review
- synthetic/deidentified shadow testing before any PHI production path
