### PR TITLE
Harness v0.1: clinical invariants, durable state and fail-closed release boundary

### DIFF
--- a/.github/workflows/harness.yml
+++ b/.github/workflows/harness.yml
@@ -1,0 +1,19 @@
+name: harness-contract
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  harness:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Compile harness checker
+        run: python -m py_compile scripts/harness_check.py
+      - name: Enforce project contract, clinical invariants and release boundary
+        run: python scripts/harness_check.py

--- a/.harness/HANDOFF.md
+++ b/.harness/HANDOFF.md
@@ -1,0 +1,28 @@
+# Harness handoff
+
+## Status
+Ready for independent verification.
+
+## Current step
+Run the harness gate and existing CareOS safety/release workflows.
+
+## Evidence
+- `AGENTS.md` makes clinical invariants and release boundaries part of the root operating map.
+- `.harness/project.json` records the research-only / no-writeback / G1-blocked boundary.
+- `scripts/harness_check.py` mechanically rejects malformed tasks, unapproved A3/A4 receipt actions and accidental weakening of the current release-boundary flags.
+- `.github/workflows/harness.yml` makes the minimum harness continuously testable.
+
+## Decisions
+- CareOS gets a stricter harness because errors can become safety-relevant even before production.
+- The current failing holdout/release blocker is a fact to preserve, not a marketing problem to rewrite.
+- Builder and Verifier stay separate for clinical logic and release claims.
+- Patient data never enters repository harness state.
+
+## Failures / uncertainties
+CI evidence is pending.
+
+## Open risks
+Harness v0.1 validates process and safety-boundary invariants; it does not provide clinical validation, regulatory approval or real-hospital evidence.
+
+## Next owner
+Verifier — run the branch workflows, inspect any failure, and upgrade the sensor/gate rather than weakening the acceptance criterion.

--- a/.harness/HANDOFF.md
+++ b/.harness/HANDOFF.md
@@ -1,16 +1,17 @@
 # Harness handoff
 
 ## Status
-Ready for independent verification.
+Verified and accepted for merge.
 
 ## Current step
-Run the harness gate and existing CareOS safety/release workflows.
+Merge PR #62. The harness gate, existing CareOS tests and CodeQL all passed on the implementation commit.
 
 ## Evidence
+- Harness workflow `33744829375`: success.
+- Test workflow `33744829063`: success.
+- CodeQL workflow `33744829056`: success.
 - `AGENTS.md` makes clinical invariants and release boundaries part of the root operating map.
-- `.harness/project.json` records the research-only / no-writeback / G1-blocked boundary.
-- `scripts/harness_check.py` mechanically rejects malformed tasks, unapproved A3/A4 receipt actions and accidental weakening of the current release-boundary flags.
-- `.github/workflows/harness.yml` makes the minimum harness continuously testable.
+- Acceptance receipt: `.harness/receipts/harness-v0.1-adoption.json`.
 
 ## Decisions
 - CareOS gets a stricter harness because errors can become safety-relevant even before production.
@@ -19,10 +20,10 @@ Run the harness gate and existing CareOS safety/release workflows.
 - Patient data never enters repository harness state.
 
 ## Failures / uncertainties
-CI evidence is pending.
+None observed in the harness, repository tests or CodeQL for this change.
 
 ## Open risks
 Harness v0.1 validates process and safety-boundary invariants; it does not provide clinical validation, regulatory approval or real-hospital evidence.
 
 ## Next owner
-Verifier — run the branch workflows, inspect any failure, and upgrade the sensor/gate rather than weakening the acceptance criterion.
+Operator — merge the verified PR, then use a fresh task contract for the next CareOS change.

--- a/.harness/active-task.json
+++ b/.harness/active-task.json
@@ -1,0 +1,26 @@
+{
+  "schema": "mikel-harness-task-v0.1",
+  "task_id": "harness-v0.1-adoption",
+  "status": "ready_for_review",
+  "goal": "Adopt Harness v0.1 around CareOS without weakening clinical provenance, safety invariants or its currently blocked production release boundary.",
+  "sources": ["README.md", "docs/GATES.md", "docs/RELEASE_ASSURANCE.md", "docs/AGENT_SECURITY_MODEL.md", ".github/workflows/"],
+  "outputs": ["AGENTS.md", ".harness/project.json", ".harness/HANDOFF.md", "scripts/harness_check.py", ".github/workflows/harness.yml"],
+  "constraints": ["Keep research/synthetic-only status.", "Keep production G1 blocked.", "Do not change clinical runtime behaviour.", "Do not broaden data or effect authority."],
+  "done_when": ["Harness structure is present.", "Mechanical harness check passes.", "CI runs the harness check on pull requests and main."],
+  "forbidden": ["Clinical use claim", "Identifiable patient-data access", "Production clinical write-back", "Release-gate weakening", "Named live KIS/LIS compatibility claim without evidence"],
+  "risk_class": "A2",
+  "approval_required": false,
+  "max_retries": 3,
+  "current_step": "run_ci",
+  "evidence": [
+    {"kind": "file", "path": "AGENTS.md", "status": "present"},
+    {"kind": "file", "path": ".harness/project.json", "status": "present"},
+    {"kind": "file", "path": "scripts/harness_check.py", "status": "present"},
+    {"kind": "file", "path": ".github/workflows/harness.yml", "status": "present"}
+  ],
+  "failures": [],
+  "uncertainties": ["Existing CareOS workflows still need to run on this branch."],
+  "next_owner": "verifier",
+  "next_step": "Run harness and relevant existing CareOS workflows; reject any change that weakens the blocked release boundary or clinical invariants.",
+  "receipt": null
+}

--- a/.harness/active-task.json
+++ b/.harness/active-task.json
@@ -1,7 +1,7 @@
 {
   "schema": "mikel-harness-task-v0.1",
   "task_id": "harness-v0.1-adoption",
-  "status": "ready_for_review",
+  "status": "completed",
   "goal": "Adopt Harness v0.1 around CareOS without weakening clinical provenance, safety invariants or its currently blocked production release boundary.",
   "sources": ["README.md", "docs/GATES.md", "docs/RELEASE_ASSURANCE.md", "docs/AGENT_SECURITY_MODEL.md", ".github/workflows/"],
   "outputs": ["AGENTS.md", ".harness/project.json", ".harness/HANDOFF.md", "scripts/harness_check.py", ".github/workflows/harness.yml"],
@@ -11,16 +11,19 @@
   "risk_class": "A2",
   "approval_required": false,
   "max_retries": 3,
-  "current_step": "run_ci",
+  "current_step": "verified",
   "evidence": [
     {"kind": "file", "path": "AGENTS.md", "status": "present"},
     {"kind": "file", "path": ".harness/project.json", "status": "present"},
     {"kind": "file", "path": "scripts/harness_check.py", "status": "present"},
-    {"kind": "file", "path": ".github/workflows/harness.yml", "status": "present"}
+    {"kind": "file", "path": ".github/workflows/harness.yml", "status": "present"},
+    {"kind": "ci", "workflow": "harness-contract", "run_id": 33744829375, "status": "success"},
+    {"kind": "ci", "workflow": "tests", "run_id": 33744829063, "status": "success"},
+    {"kind": "ci", "workflow": "codeql", "run_id": 33744829056, "status": "success"}
   ],
   "failures": [],
-  "uncertainties": ["Existing CareOS workflows still need to run on this branch."],
-  "next_owner": "verifier",
-  "next_step": "Run harness and relevant existing CareOS workflows; reject any change that weakens the blocked release boundary or clinical invariants.",
-  "receipt": null
+  "uncertainties": [],
+  "next_owner": "operator",
+  "next_step": "Merge PR #62; future substantial tasks start from a fresh explicit contract and preserve the current clinical release boundary until evidence justifies a governed change.",
+  "receipt": ".harness/receipts/harness-v0.1-adoption.json"
 }

--- a/.harness/project.json
+++ b/.harness/project.json
@@ -1,0 +1,47 @@
+{
+  "schema": "mikel-harness-project-v0.1",
+  "project": {
+    "name": "CareOS",
+    "repository": "mikelninh/care-os",
+    "purpose": "Source-linked clinical context and assurance layer for research/synthetic evaluation with human authority and fail-closed safety boundaries."
+  },
+  "sources_of_truth": [
+    {"area": "product_status", "paths": ["README.md", "docs/CURRENT_STATUS_AND_GAPS.md"]},
+    {"area": "release_and_claims", "paths": ["docs/RELEASE_ASSURANCE.md", "docs/GATES.md", "docs/CLAIM_EVIDENCE_MATRIX.md"]},
+    {"area": "agent_security", "paths": ["docs/AGENT_SECURITY_MODEL.md"]},
+    {"area": "runtime", "paths": ["app/", "architecture/"]},
+    {"area": "evidence", "paths": ["benchmark/", "proof/"]},
+    {"area": "interoperability", "paths": ["compatibility/"]},
+    {"area": "verification", "paths": [".github/workflows/"]},
+    {"area": "work_state", "paths": [".harness/"]}
+  ],
+  "roles": ["chief", "scout", "builder", "verifier", "operator"],
+  "commands": {
+    "harness_check": ["python scripts/harness_check.py"],
+    "quick_verification": ["pytest -q"],
+    "full_ci_reference": [".github/workflows/"]
+  },
+  "sensors": {
+    "clinical_truth": ["source provenance", "lifecycle state", "freshness", "contradictions"],
+    "invariants": ["pending_not_negative", "unavailable_not_absent", "documented_therapy_not_ai_recommendation", "agent_draft_not_source_truth"],
+    "agent_safety": ["patient scope", "encounter scope", "tool/operation budgets", "human review"],
+    "release": ["holdout metrics", "claim evidence", "production gates", "red-team workflows"],
+    "interoperability": ["FHIR/ISiK validation", "synthetic HL7 paths", "explicit unproven live integrations"]
+  },
+  "action_policy": {
+    "A0": {"meaning": "observe", "approval_required": false},
+    "A1": {"meaning": "local_reversible", "approval_required": false},
+    "A2": {"meaning": "shared_reversible", "approval_required": false},
+    "A3": {"meaning": "consequential", "approval_required": true},
+    "A4": {"meaning": "clinical_or_high_impact", "approval_required": true}
+  },
+  "retry_policy": {"max_retries": 3, "escalate_on_same_failure": 2},
+  "receipt_dir": ".harness/receipts",
+  "failure_upgrade_required": true,
+  "current_release_boundary": {
+    "research_synthetic_only": true,
+    "clinical_use": false,
+    "production_writeback": false,
+    "g1_production": "blocked"
+  }
+}

--- a/.harness/receipts/README.md
+++ b/.harness/receipts/README.md
@@ -1,0 +1,7 @@
+# Change receipts
+
+Store compact JSON receipts for accepted, rejected or partial substantial runs here.
+
+Receipts are append-only process evidence. Capture task, context sources, tools, verification results, retries/corrections, approvals, external actions, rollback point and next owner.
+
+Never store patient data, source clinical documents, identifiers, secrets, credentials or privileged hospital information in receipts.

--- a/.harness/receipts/harness-v0.1-adoption.json
+++ b/.harness/receipts/harness-v0.1-adoption.json
@@ -1,0 +1,22 @@
+{
+  "schema": "mikel-harness-receipt-v0.1",
+  "task_id": "harness-v0.1-adoption",
+  "verdict": "accepted",
+  "context_sources": ["README.md", "docs/GATES.md", "docs/RELEASE_ASSURANCE.md", "docs/AGENT_SECURITY_MODEL.md", ".github/workflows/"],
+  "tools_used": ["GitHub branch", "GitHub pull request", "GitHub Actions"],
+  "verification": {
+    "implementation_commit": "dd5246e64ca5803c5f12c05561e21402bf0c1aec",
+    "harness_workflow": {"run_id": 33744829375, "conclusion": "success"},
+    "tests": {"run_id": 33744829063, "conclusion": "success"},
+    "codeql": {"run_id": 33744829056, "conclusion": "success"}
+  },
+  "human_corrections": 0,
+  "retries": 0,
+  "external_actions": [
+    {"kind": "open_pull_request", "target": "#62", "risk_class": "A2", "approved": true}
+  ],
+  "accepted_artifact": "PR #62",
+  "rollback_point": "a5279e2feffd6f2ebf7849505a91ce0557de1c88",
+  "next_owner": "operator",
+  "next_step": "Merge PR #62."
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,117 @@
+# AGENTS.md — CareOS
+
+## Mission
+Return time to care without making clinical information less trustworthy. Build source-linked, bounded clinical context tooling for research and synthetic evaluation while keeping clinical truth, patient safety and real-world authority outside the model.
+
+## Start here
+1. Read `README.md`.
+2. Read `.harness/project.json`.
+3. Read `.harness/active-task.json` and `.harness/HANDOFF.md`.
+4. For safety-relevant work, read the exact release, gate and agent-security documents that govern the change.
+
+## Source-of-truth map
+- Product status and proof boundary: `README.md`
+- Current gaps: `docs/CURRENT_STATUS_AND_GAPS.md`
+- Release assurance: `docs/RELEASE_ASSURANCE.md`
+- Production gates: `docs/GATES.md`
+- Claim/evidence mapping: `docs/CLAIM_EVIDENCE_MATRIX.md`
+- Agent security: `docs/AGENT_SECURITY_MODEL.md`
+- Clinical study protocol: `docs/TIME_RETURNED_TO_CARE_STUDY.md`
+- Runtime: `app/`
+- Architecture: `architecture/`
+- Benchmarks/evidence: `benchmark/`, `proof/`
+- Interoperability: `compatibility/`
+- Deployment scaffolding: `deploy/`, `Dockerfile`
+- Current work state: `.harness/`
+- CI truth: `.github/workflows/`
+
+## Contract before work
+Every substantial task must define:
+- goal
+- authoritative sources
+- outputs
+- constraints
+- done criteria
+- forbidden actions
+- risk class
+- retry budget
+- next owner
+
+Do not silently redefine a clinical claim, promote a research result, or hide a failing safety metric.
+
+## Roles
+- Chief: triage, decompose, route, collect. Does not make clinical decisions.
+- Scout: retrieves source evidence, standards and research material. Read-only by default.
+- Builder: creates code, mappings, UX and synthetic artefacts in an isolated workspace.
+- Verifier: independently checks safety invariants, tests, benchmarks, provenance and claims.
+- Operator: performs only approved external/deployment actions after policy gates.
+
+## Action classes
+- A0 Observe — read/search/analyse. Automatic.
+- A1 Local reversible — draft/test/edit isolated synthetic work. Automatic.
+- A2 Shared reversible — branch, PR, preview, issue. Logged; normally automatic.
+- A3 Consequential — publish, deploy, send, write to external systems. Human approval required.
+- A4 High-impact — identifiable patient-data access/egress, clinical write-back, patient-care actions, destructive production changes, clinical/regulatory claims. Explicit approval plus stronger independent verification; many A4 actions remain forbidden by current project status.
+
+Trust the action class, not the agent personality.
+
+## Four clinical correctness invariants
+1. Pending is not negative.
+2. Unavailable is not absent.
+3. Documented therapy is not an AI recommendation.
+4. Agent draft is not source truth.
+
+Treat violations as harness failures, not wording problems.
+
+## Verification
+Minimum harness check:
+`python scripts/harness_check.py`
+
+Project-specific verification comes from the relevant workflow under `.github/workflows/` plus the safety/release docs above.
+
+Never claim a test, benchmark, compatibility path or clinical metric passed unless it actually ran or was directly observed and its evidence is captured.
+
+## Durable state
+The conversation is not the system of record.
+Keep current work in `.harness/active-task.json`.
+Keep handoff context in `.harness/HANDOFF.md`.
+Keep accepted run receipts in `.harness/receipts/`.
+
+Memory may preserve preferences; current patient/context data, evidence, clinical rules, compatibility, holdout results, release gates and deployment state must be re-opened from authoritative sources.
+
+## Handoffs
+A handoff must state status, current step, evidence, decisions, failures/uncertainties, open risks, next owner and exact next action.
+
+Safety-relevant work may not be passed as chat-only context.
+
+## Retries
+Use bounded local repair loops. Default maximum: 3 attempts.
+If the same failure repeats twice, stop and improve the sensor, fixture, source rule, gate or escalation path.
+
+## Failure upgrades
+- missing clinical context -> source/provenance requirement
+- pending treated as negative -> invariant regression test
+- unavailable treated as absent -> availability-state test
+- draft treated as truth -> authority/provenance gate
+- missed contradiction -> contradiction sensor/gold case
+- poor holdout metric -> keep release blocked; improve evidence/system
+- repeated loop -> retry cap/escalation
+- unsafe action -> permission gate
+- lost decision -> durable state
+- unknown failure -> trace/evidence capture
+
+Never improve the copy to conceal a blocked gate.
+
+## Hard boundaries
+- Research/synthetic evaluation only under current project status; not for clinical use.
+- No production clinical write-back under the current release boundary.
+- The model may propose structure; it does not create trusted clinical truth.
+- Human authority remains outside the model.
+- Missing or unavailable evidence must stay explicit.
+- The current frozen holdout blocker may not be relabelled as production readiness.
+- No named KIS/LIS compatibility claim without approved real-environment evidence.
+- Synthetic/deidentified evidence is never identifiable-patient production evidence.
+- Identifiable patient data, credentials and secrets never belong in harness state or receipts.
+
+## Definition of done
+Work is done only when contract criteria are evidenced, provenance and uncertainty remain visible, relevant safety/release gates still hold, rollback/next step is known, and any required human or independent approval is recorded.

--- a/scripts/harness_check.py
+++ b/scripts/harness_check.py
@@ -1,0 +1,155 @@
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path.cwd()
+errors: list[str] = []
+
+
+def fail(message: str) -> None:
+    errors.append(message)
+
+
+def read_json(path: str) -> dict:
+    return json.loads((ROOT / path).read_text(encoding="utf-8"))
+
+
+required = [
+    "AGENTS.md",
+    ".harness/project.json",
+    ".harness/active-task.json",
+    ".harness/HANDOFF.md",
+    ".harness/receipts/README.md",
+]
+for item in required:
+    if not (ROOT / item).exists():
+        fail(f"missing required file {item}")
+
+project = None
+task = None
+try:
+    project = read_json(".harness/project.json")
+except Exception as exc:
+    fail(f"invalid .harness/project.json: {exc}")
+try:
+    task = read_json(".harness/active-task.json")
+except Exception as exc:
+    fail(f"invalid .harness/active-task.json: {exc}")
+
+if project:
+    if project.get("schema") != "mikel-harness-project-v0.1":
+        fail("unsupported project schema")
+    ident = project.get("project") or {}
+    if not ident.get("name") or not ident.get("repository"):
+        fail("project identity is incomplete")
+    if len(project.get("sources_of_truth") or []) < 3:
+        fail("sources_of_truth must map at least three areas")
+    if not project.get("action_policy") or not project.get("retry_policy"):
+        fail("action and retry policies are required")
+    maximum = (project.get("retry_policy") or {}).get("max_retries")
+    if not isinstance(maximum, int) or not 1 <= maximum <= 5:
+        fail("project max_retries must be between 1 and 5")
+    boundary = project.get("current_release_boundary") or {}
+    if boundary.get("research_synthetic_only") is not True:
+        fail("CareOS harness must preserve research_synthetic_only=true")
+    if boundary.get("clinical_use") is not False:
+        fail("CareOS harness must preserve clinical_use=false")
+    if boundary.get("production_writeback") is not False:
+        fail("CareOS harness must preserve production_writeback=false")
+    if boundary.get("g1_production") != "blocked":
+        fail("CareOS harness must preserve g1_production=blocked until independently changed with evidence")
+
+if task and project:
+    statuses = {"queued", "in_progress", "blocked", "ready_for_review", "completed", "abandoned"}
+    if task.get("schema") != "mikel-harness-task-v0.1":
+        fail("unsupported task schema")
+    if not task.get("task_id") or not task.get("goal"):
+        fail("task_id and goal are required")
+    if task.get("status") not in statuses:
+        fail(f"invalid task status {task.get('status')}")
+    for key in ("sources", "outputs", "constraints", "done_when", "forbidden"):
+        if not isinstance(task.get(key), list) or not task[key]:
+            fail(f"{key} must be a non-empty array")
+    risk = task.get("risk_class")
+    if risk not in (project.get("action_policy") or {}):
+        fail(f"unknown risk_class {risk}")
+    if not isinstance(task.get("approval_required"), bool):
+        fail("approval_required must be boolean")
+    if risk in {"A3", "A4"} and task.get("approval_required") is not True:
+        fail(f"{risk} tasks require human approval")
+    maximum = project["retry_policy"]["max_retries"]
+    retries = task.get("max_retries")
+    if not isinstance(retries, int) or retries < 0 or retries > maximum:
+        fail(f"task max_retries must be between 0 and {maximum}")
+    if task.get("status") in {"ready_for_review", "completed"} and not task.get("evidence"):
+        fail(f"{task.get('status')} tasks need evidence")
+    for evidence in task.get("evidence") or []:
+        if evidence.get("status") == "present" and evidence.get("path") and not (ROOT / evidence["path"]).exists():
+            fail(f"evidence path does not exist: {evidence['path']}")
+    if task.get("status") == "completed":
+        receipt_path = task.get("receipt")
+        if not receipt_path or not (ROOT / receipt_path).exists():
+            fail("completed task must reference an existing receipt")
+        else:
+            try:
+                receipt = read_json(receipt_path)
+                if receipt.get("verdict") != "accepted":
+                    fail("completed task receipt must have verdict=accepted")
+            except Exception as exc:
+                fail(f"invalid completion receipt: {exc}")
+
+agents = ROOT / "AGENTS.md"
+if agents.exists():
+    text = agents.read_text(encoding="utf-8")
+    if len(text.splitlines()) > 200:
+        fail("AGENTS.md must remain under 200 lines")
+    for phrase in (
+        "Source-of-truth map",
+        "Action classes",
+        "Four clinical correctness invariants",
+        "Durable state",
+        "Failure upgrades",
+        "Definition of done",
+    ):
+        if phrase not in text:
+            fail(f"AGENTS.md missing section: {phrase}")
+    for invariant in (
+        "Pending is not negative",
+        "Unavailable is not absent",
+        "Documented therapy is not an AI recommendation",
+        "Agent draft is not source truth",
+    ):
+        if invariant not in text:
+            fail(f"AGENTS.md missing clinical invariant: {invariant}")
+
+handoff = ROOT / ".harness/HANDOFF.md"
+if handoff.exists():
+    text = handoff.read_text(encoding="utf-8")
+    for heading in ("## Status", "## Current step", "## Evidence", "## Open risks", "## Next owner"):
+        if heading not in text:
+            fail(f"HANDOFF.md missing heading: {heading}")
+
+receipt_dir = ROOT / ((project or {}).get("receipt_dir") or ".harness/receipts")
+if receipt_dir.exists():
+    for file in receipt_dir.glob("*.json"):
+        try:
+            receipt = json.loads(file.read_text(encoding="utf-8"))
+            for field in ("schema", "task_id", "verdict", "context_sources", "tools_used", "verification", "external_actions", "rollback_point", "next_owner"):
+                if field not in receipt:
+                    fail(f"{file.name} missing receipt field {field}")
+            if receipt.get("verdict") not in {"accepted", "rejected", "partial"}:
+                fail(f"{file.name} has invalid verdict {receipt.get('verdict')}")
+            for action in receipt.get("external_actions") or []:
+                if action.get("risk_class") in {"A3", "A4"} and action.get("approved") is not True:
+                    fail(f"{file.name} contains an unapproved consequential external action")
+        except Exception as exc:
+            fail(f"invalid receipt {file.name}: {exc}")
+
+if errors:
+    for error in errors:
+        print(f"HARNESS FAIL: {error}", file=sys.stderr)
+    raise SystemExit(1)
+
+print(f"Harness OK: {project['project']['name']} / {task['task_id']} / {task['status']}")


### PR DESCRIPTION
Adds a repository-native harness tailored to CareOS's safety surface:

- small root `AGENTS.md` source map
- the four clinical correctness invariants promoted to root operating rules
- durable `.harness/` task + handoff state
- A0–A4 action classes, with clinical/high-impact work requiring explicit approval
- bounded retries and failure-to-infrastructure rule
- append-only change receipts
- mechanical checker that preserves research/synthetic-only, no clinical use, no production write-back and G1=blocked
- dedicated CI harness gate

This PR does not change clinical runtime behaviour, holdout metrics, interoperability claims or production authority. It is deliberately `ready_for_review` until CI provides evidence.