### PR TITLE
Add roadmap truth contract

### DIFF
--- a/.harness/roadmap.json
+++ b/.harness/roadmap.json
@@ -1,0 +1,27 @@
+{
+  "schema": "mikel-harness-roadmap-v0.1",
+  "project": "CareOS",
+  "north_star": "Return time to care — safety gated — by making source-linked clinical context easier to find, reconcile and prepare without losing provenance, uncertainty or human authority.",
+  "achieved": [
+    {"title": "Source-linked clinical context, lifecycle and stale-artifact invalidation", "evidence": ["README.md", "docs/RELEASE_ASSURANCE.md"]},
+    {"title": "Bounded agent gateway plus FHIR/ISiK/HL7 research paths", "evidence": ["README.md", "docs/AGENT_SECURITY_MODEL.md"]},
+    {"title": "500-case holdout exposed the real recall blocker instead of hiding it", "evidence": ["README.md", "docs/CURRENT_STATUS_AND_GAPS.md"]}
+  ],
+  "current": {
+    "title": "Improve recall without sacrificing precision, provenance or reviewability",
+    "status": "blocked",
+    "outcome": "Earn the right to move from synthetic proof toward clinician evaluation while keeping production G1 blocked until evidence improves."
+  },
+  "next": [
+    {"title": "Raise clinical-truth recall on the frozen holdout while preserving safety invariants", "why": "26.32% recall with 100% review burden is the concrete blocker to advancing the proof ladder."},
+    {"title": "Run real clinicians on synthetic paired cases", "why": "The north-star metric is time returned to care without worse verification or error behaviour."},
+    {"title": "Obtain independent clinical, privacy, security and hospital-IT critique", "why": "External evidence is required before any real-data or named-system claim."}
+  ],
+  "later": [
+    "Map one real non-secret hospital capability surface and approved sandbox.",
+    "Run a governed shadow workflow for physician morning review and documentation preparation.",
+    "Earn a bounded read-only pilot before any consideration of write-back."
+  ],
+  "sources": ["README.md", "docs/CURRENT_STATUS_AND_GAPS.md", "docs/GATES.md", "docs/AGENT_SECURITY_MODEL.md", "proof/README.md"],
+  "updated_at": "2026-09-03"
+}


### PR DESCRIPTION
Adds `.harness/roadmap.json` so Mission Control can show CareOS North Star, earned milestones, current blocker, next wins and later proof ladder from explicit project truth. No clinical/runtime authority changes.